### PR TITLE
Expose real-time stats: bill/s, heat trend, per-GPU income

### DIFF
--- a/internal/game/stats.go
+++ b/internal/game/stats.go
@@ -1,0 +1,114 @@
+package game
+
+import (
+	"time"
+
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/internal/data"
+)
+
+// This file exposes read-only, point-in-time rate computations that mirror
+// the tick loop's math. Used by the UI to render live "bill/s", "net/s",
+// heat trend, etc. without inventing numbers that would drift from what
+// the simulation actually does.
+
+// EarnRatePerSec returns the dollar earn rate for a single running GPU at
+// the current BTC price + active modifiers + active difficulty.
+func (s *State) GPUEarnRatePerSec(g *GPU) float64 {
+	if g.Status != "running" {
+		return 0
+	}
+	now := time.Now().Unix()
+	if s.IsMiningPaused(now) {
+		return 0
+	}
+	eff, _, _, _ := s.GPUStats(g)
+	effFactor := 1.0
+	if room := s.Rooms[g.Room]; room != nil && room.Heat > 0.8*room.MaxHeat {
+		effFactor = 0.5
+	}
+	earnMult := s.earnMultiplier(now)
+	btcPerSec := eff * earnMult * effFactor * s.DifficultyEarnMult()
+	return btcPerSec * s.BTCPriceAt(now)
+}
+
+// RoomEarnRatePerSec is the sum of per-GPU earn rates for every running GPU
+// in the given room.
+func (s *State) RoomEarnRatePerSec(roomID string) float64 {
+	var total float64
+	for _, g := range s.GPUs {
+		if g.Room != roomID {
+			continue
+		}
+		total += s.GPUEarnRatePerSec(g)
+	}
+	return total
+}
+
+// RoomBillRatePerSec is the per-second cost of electricity + rent for the
+// given room, respecting skill + difficulty multipliers.
+func (s *State) RoomBillRatePerSec(roomID string) float64 {
+	roomDef, ok := data.RoomByID(roomID)
+	if !ok {
+		return 0
+	}
+	billMult := s.BillMult() * s.DifficultyBillMult()
+
+	var volt float64
+	for _, g := range s.GPUs {
+		if g.Room != roomID || g.Status != "running" {
+			continue
+		}
+		_, pow, _, _ := s.GPUStats(g)
+		volt += pow
+	}
+	// ElectricPerVoltMin is per minute — divide by 60 for per-second.
+	elec := volt * ElectricPerVoltMin * roomDef.ElectricCostMult * billMult / 60.0
+	rent := float64(roomDef.RentPerHour) * s.DifficultyBillMult() / 3600.0
+	return elec + rent
+}
+
+// RoomHeatDeltaPerSec is the net heat change per second: GPU output minus
+// passive cooling (room base × cooling-upgrade bonus).
+func (s *State) RoomHeatDeltaPerSec(roomID string) float64 {
+	roomDef, ok := data.RoomByID(roomID)
+	if !ok {
+		return 0
+	}
+	room := s.Rooms[roomID]
+	if room == nil {
+		return 0
+	}
+	coolingBonus := 1.0 + 0.25*float64(room.CoolingLvl)
+	var heatIn float64
+	for _, g := range s.GPUs {
+		if g.Room != roomID || g.Status != "running" {
+			continue
+		}
+		_, _, hOut, _ := s.GPUStats(g)
+		heatIn += hOut
+	}
+	delta := heatIn - roomDef.BaseCooling*coolingBonus
+	// Cap at floor temp (20°C) so trend matches sim (Heat clamps low).
+	if room.Heat <= 20 && delta < 0 {
+		delta = 0
+	}
+	return delta
+}
+
+// SecondsUntilNextBill is the countdown (in whole seconds, 0..60) until
+// the next billing cycle fires.
+func (s *State) SecondsUntilNextBill() int {
+	remaining := 60 - (time.Now().Unix() - s.LastBillUnix)
+	if remaining < 0 {
+		return 0
+	}
+	if remaining > 60 {
+		return 60
+	}
+	return int(remaining)
+}
+
+// NetRatePerSec is the room's earn rate minus its bill rate. Positive is good.
+func (s *State) RoomNetRatePerSec(roomID string) float64 {
+	return s.RoomEarnRatePerSec(roomID) - s.RoomBillRatePerSec(roomID)
+}

--- a/internal/i18n/en.go
+++ b/internal/i18n/en.go
@@ -39,7 +39,10 @@ var enStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.meters":     "⚡ %.0f V/s draw   🌡  %.0f°C   slots %d/%d",
+	"dash.line.volt":  "⚡ %.0fV draw  ·  bill −$%.3f/s  ·  next bill %ds",
+	"dash.line.heat":  "🌡 %.0f°C / %.0f max  ·  trend %+.1f/s",
+	"dash.line.cash":  "📈 earn +$%.3f/s  ·  net %+.3f/s",
+	"dash.slots_of":   "slots %d/%d",
 	"dash.rack":       "GPU Rack",
 	"dash.empty_hint": "  (empty — press [2] to go to the store)",
 	"dash.slot_empty": "  %d. (empty)",

--- a/internal/i18n/zh.go
+++ b/internal/i18n/zh.go
@@ -39,7 +39,10 @@ var zhStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.meters":     "⚡ 耗电 %.0f V/s   🌡  %.0f°C   槽位 %d/%d",
+	"dash.line.volt":  "⚡ %.0fV 耗电  ·  账单 −$%.3f/秒  ·  下次结算 %d 秒",
+	"dash.line.heat":  "🌡 %.0f°C / 最高 %.0f  ·  趋势 %+.1f/秒",
+	"dash.line.cash":  "📈 收益 +$%.3f/秒  ·  扣费后净 %+.3f/秒",
+	"dash.slots_of":   "槽位 %d/%d",
 	"dash.rack":       "显卡架",
 	"dash.empty_hint": "  （空的——按 [2] 去商店）",
 	"dash.slot_empty": "  %d. （空）",

--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -39,7 +39,29 @@ func (a App) renderRoomPanel(def data.RoomDef) string {
 		_, pow, _, _ := a.state.GPUStats(g)
 		volt += pow
 	}
-	lines = append(lines, i18n.T("dash.meters", volt, heat, len(gpus), def.Slots))
+
+	roomID := def.ID
+	bill := a.state.RoomBillRatePerSec(roomID)
+	earn := a.state.RoomEarnRatePerSec(roomID)
+	net := earn - bill
+	heatDelta := a.state.RoomHeatDeltaPerSec(roomID)
+	nextBill := a.state.SecondsUntilNextBill()
+
+	var maxHeat float64 = 90
+	if rs := a.state.Rooms[roomID]; rs != nil {
+		maxHeat = rs.MaxHeat
+	}
+
+	netStyle := lipgloss.NewStyle().Foreground(OppGreen)
+	if net < 0 {
+		netStyle = lipgloss.NewStyle().Foreground(CrisisRed)
+	}
+
+	lines = append(lines, fmt.Sprintf("%s   %s",
+		VoltStyle.Render(i18n.T("dash.line.volt", volt, bill, nextBill)),
+		DimStyle.Render(i18n.T("dash.slots_of", len(gpus), def.Slots))))
+	lines = append(lines, HeatStyle.Render(i18n.T("dash.line.heat", heat, maxHeat, heatDelta)))
+	lines = append(lines, netStyle.Render(i18n.T("dash.line.cash", earn, net)))
 	lines = append(lines, "")
 
 	lines = append(lines, HeaderStyle.Render(i18n.T("dash.rack")))

--- a/internal/ui/gpus.go
+++ b/internal/ui/gpus.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/internal/data"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/internal/game"
@@ -52,7 +53,14 @@ func (a App) renderGPUsView() string {
 		if g.UpgradeLevel > 0 {
 			upMark = fmt.Sprintf(" +%d", g.UpgradeLevel)
 		}
-		line := fmt.Sprintf("%s#%-3d %-36s%s  %-12s  %-24s  durab %.1fh",
+		rate := a.state.GPUEarnRatePerSec(g)
+		rateCell := ""
+		if rate > 0 {
+			rateCell = lipgloss.NewStyle().Foreground(OppGreen).Render(fmt.Sprintf("$%.3f/s", rate))
+		} else {
+			rateCell = DimStyle.Render("—")
+		}
+		line := fmt.Sprintf("%s#%-3d %-36s%s  %-12s  %-18s  durab %5.1fh  %s",
 			marker,
 			g.InstanceID,
 			gpuDisplayName(a.state, g),
@@ -60,6 +68,7 @@ func (a App) renderGPUsView() string {
 			statusDecor,
 			roomName,
 			g.HoursLeft,
+			rateCell,
 		)
 		lines = append(lines, line)
 	}


### PR DESCRIPTION
## Summary

The simulation was a black box. Dashboard showed point values (voltage, heat, slot count) but not the *rates* that determine whether to buy a 4090 or two 2070s. Bills fired every minute as opaque log lines. This PR plumbs the tick loop's math out to the UI.

## What's new

\`internal/game/stats.go\` — read-only rate helpers that mirror \`advanceMining\` / \`advanceBilling\`:

- \`GPUEarnRatePerSec(g)\` — per-GPU \$/s, honoring modifiers / overheating / pause / difficulty
- \`RoomEarnRatePerSec(id)\` — sum over running GPUs in a room
- \`RoomBillRatePerSec(id)\` — per-second electricity + rent (all multipliers applied)
- \`RoomHeatDeltaPerSec(id)\` — GPU output minus cooling, clamped at floor
- \`RoomNetRatePerSec(id)\` — earn minus bill
- \`SecondsUntilNextBill()\` — 0..60 countdown

**Dashboard** — three colored meter lines instead of one:

\`\`\`
⚡ 48V draw  ·  bill −\$0.0067/s  ·  next bill 42s
🌡 23°C / 90°C max  ·  trend +1.2/s
📈 earn +\$0.384/s  ·  net +\$0.377/s
\`\`\`

Net line goes red when negative.

**GPUs list** — rightmost \`\$/s\` column per GPU (green when producing, dim dash when idle/broken/shipping).

**i18n** — dropped single-line \`dash.meters\`; added three new keys in EN + ZH.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` both binaries
- [x] \`go test -race -count=1 ./...\` all pass
- [ ] (reviewer) Launch the binary, verify live meter updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)