### PR TITLE
chore: automate releases on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed so gh release --generate-notes can diff against previous tag
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Vet + test sanity check
+        run: |
+          go vet ./...
+          go test -count=1 ./...
+
+      - name: Cross-compile 8 binaries
+        run: |
+          mkdir -p bin
+          for target in "windows amd64 .exe" "linux amd64 " "darwin amd64 " "darwin arm64 "; do
+            set -- $target
+            os=$1; arch=$2; ext=$3
+            for cmd in meowmine meowmine-ssh; do
+              echo "building $cmd-$os-$arch$ext"
+              GOOS=$os GOARCH=$arch go build -ldflags "-s -w" \
+                -o "bin/$cmd-$os-$arch$ext" "./cmd/$cmd"
+            done
+          done
+          ls -lh bin/
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            bin/*

--- a/README.md
+++ b/README.md
@@ -10,19 +10,22 @@ The idea is you can leave it open in a `tmux` pane and come back to richer cats.
 
 ### Option A — pre-built binary (no Go needed)
 
-Grab the release binary for your platform from the [Releases](https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases) page (or ask a maintainer) and run it:
+Download from the [**latest release**](https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases/latest):
 
-| Platform | File |
-|---|---|
-| Windows (x64) | `meowmine-windows-amd64.exe` |
-| Linux (x64) | `meowmine-linux-amd64` |
-| macOS (Intel) | `meowmine-darwin-amd64` |
-| macOS (Apple Silicon) | `meowmine-darwin-arm64` |
+| Platform | Local TUI | SSH server |
+|---|---|---|
+| Windows (x64) | `meowmine-windows-amd64.exe` | `meowmine-ssh-windows-amd64.exe` |
+| Linux (x64) | `meowmine-linux-amd64` | `meowmine-ssh-linux-amd64` |
+| macOS (Intel) | `meowmine-darwin-amd64` | `meowmine-ssh-darwin-amd64` |
+| macOS (Apple Silicon) | `meowmine-darwin-arm64` | `meowmine-ssh-darwin-arm64` |
 
 ```bash
 # Linux / macOS
 chmod +x meowmine-linux-amd64
 ./meowmine-linux-amd64
+
+# macOS — if Gatekeeper complains, strip the quarantine flag:
+xattr -d com.apple.quarantine meowmine-darwin-*
 
 # Windows (PowerShell or cmd)
 .\meowmine-windows-amd64.exe


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` so future releases happen on tag push instead of manual \`make release\` + \`gh release create\`.

Flow when a \`v*\` tag lands:
1. **Pre-flight** — \`go vet\` + \`go test\` run first so a broken tagged commit aborts before publishing
2. **Cross-compile** — same 8-binary matrix as \`make release\` (windows/linux/darwin × amd64/arm64 × meowmine/meowmine-ssh)
3. **Publish** — \`gh release create \$TAG --generate-notes\` uploads binaries as assets; GitHub auto-writes release notes from the commit + PR history since the previous tag

Only uses the built-in \`GITHUB_TOKEN\`, no repo secrets needed.

## README tweak

The \"Option A\" section now:
- Links straight to \`/releases/latest\` (no click-through)
- Lists the SSH-server binary alongside the TUI binary per platform
- Adds the macOS Gatekeeper \`xattr\` command for users who hit quarantine

## Context

v0.1.0 was published manually today ([link](https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases/tag/v0.1.0)). All subsequent tags will go through this workflow.

## Test plan

- [ ] Merge this PR
- [ ] \`git tag v0.1.1 && git push origin v0.1.1\` (or bump the minor)
- [ ] Watch Actions → should see a single job build + publish
- [ ] Verify new release appears at /releases with all 8 assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)