### PR TITLE
fix: rebind global save to [S] to free [s] for view actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Each client gets their own save keyed by SHA-256 of their SSH public key, stored
 | `enter` / `b` | Confirm / buy / hire |
 | `u` | Upgrade GPU · Unlock room · Unlock skill |
 | `r` | Repair GPU · Start research (lab) |
-| `s` | Scrap GPU · Save (dashboard) |
+| `s` | Scrap GPU |
+| `S` | Save (any view) |
 | `f` | Fire merc |
 | `b` | Bribe merc (+15 loyalty for $200) · cycle lab boost combo |
 | `t` | Cycle lab tier |

--- a/internal/i18n/en.go
+++ b/internal/i18n/en.go
@@ -23,7 +23,7 @@ var enStrings = map[string]string{
 	"hdr.frags": "frags %d",
 	"hdr.price": "$%.0f/BTC",
 
-	"footer.keys": "[space] pause  [s] save  [L] lang  [?] help  [q] quit",
+	"footer.keys": "[space] pause  [S] save  [L] lang  [?] help  [q] quit",
 
 	// Welcome / splash.
 	"welcome.title":    "🐾 Kitten Crypto Mining Ventures",
@@ -127,7 +127,7 @@ var enStrings = map[string]string{
 	"help.view.9":     "[9]  prestige — retire & buy legacy perks",
 	"help.global":     "Global",
 	"help.g.space":    "[space]  pause / resume",
-	"help.g.save":     "[s]       save (dashboard only — other views reuse 's')",
+	"help.g.save":     "[S]       save (any view)",
 	"help.g.pump":     "[p]       Pump & Dump ability (dashboard, if unlocked)",
 	"help.g.lang":     "[L]       cycle language",
 	"help.g.quit":     "[q]       quit (auto-saves)",

--- a/internal/i18n/zh.go
+++ b/internal/i18n/zh.go
@@ -23,7 +23,7 @@ var zhStrings = map[string]string{
 	"hdr.frags": "碎片 %d",
 	"hdr.price": "$%.0f/BTC",
 
-	"footer.keys": "[空格]暂停  [s]存档  [L]语言  [?]帮助  [q]退出",
+	"footer.keys": "[空格]暂停  [S]存档  [L]语言  [?]帮助  [q]退出",
 
 	// Welcome / splash.
 	"welcome.title":    "🐾 喵星挖矿：加密猫的修罗场",
@@ -127,7 +127,7 @@ var zhStrings = map[string]string{
 	"help.view.9":      "[9]  转生 —— 退休 + 购买 Legacy 特权",
 	"help.global":      "全局",
 	"help.g.space":     "[空格]   暂停 / 继续",
-	"help.g.save":      "[s]      存档（仅主面板——其他视图里 s 有其他含义）",
+	"help.g.save":      "[S]      存档（任意视图）",
 	"help.g.pump":      "[p]      拉盘技能（主面板，需解锁）",
 	"help.g.lang":      "[L]      循环切换语言",
 	"help.g.quit":      "[q]      退出（自动存档）",

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -250,6 +250,13 @@ func (a App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a = a.withStatus(i18n.T("status.vent"))
 		}
 		return a, nil
+	case "S":
+		if err := a.saveNow(); err != nil {
+			a = a.withStatus(i18n.T("status.save_failed", err))
+		} else {
+			a = a.withStatus(i18n.T("status.saved"))
+		}
+		return a, nil
 	}
 
 	// View-specific.
@@ -271,13 +278,6 @@ func (a App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Dashboard-only fallbacks.
-	if key == "s" {
-		if err := a.saveNow(); err != nil {
-			a = a.withStatus(i18n.T("status.save_failed", err))
-		} else {
-			a = a.withStatus(i18n.T("status.saved"))
-		}
-	}
 	if key == "p" {
 		if err := a.state.TriggerPumpDump(); err != nil {
 			a = a.withStatus(i18n.T("status.error_prefix") + err.Error())


### PR DESCRIPTION
## Summary

- Save now lives on capital **[S]** (matches `[L]` lang / `[V]` vent convention) and works from any view.
- `[s]` is free for per-view actions (scrap on GPU view, etc.) with no ambiguity.
- Footer, in-game help, and README key table updated for both EN and 中文.

## Why

On the GPU view the footer showed `[s] 存档` while the view itself uses `[s]` to scrap a card. The dispatcher already routed correctly (scrap wins), but the hint was misleading.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Run locally, confirm `S` saves from dashboard/store/gpus/rooms, and `s` on GPU view still scraps without a save status flashing