### PR TITLE
ci: auto-bump Homebrew formula on release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,20 @@ jobs:
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
             bin/*
+
+      - name: Bump Homebrew formula on main
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          ruby scripts/update-formula.rb "$VERSION"
+          if git diff --quiet Formula/meowmine.rb; then
+            echo "Formula already up to date"
+            exit 0
+          fi
+          git add Formula/meowmine.rb
+          git commit -m "chore: bump formula to $VERSION"
+          git push origin main

--- a/Formula/meowmine.rb
+++ b/Formula/meowmine.rb
@@ -4,7 +4,7 @@ class Meowmine < Formula
   version "0.1.0"
   license "MIT"
 
-  base = "https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases/download/v0.1.0"
+  base = "https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases/download/v#{version}"
 
   on_macos do
     on_arm do

--- a/scripts/update-formula.rb
+++ b/scripts/update-formula.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# Rewrites Formula/meowmine.rb to match the given VERSION and the sha256s of the
+# built binaries in bin/. Used by the release workflow after a tag build so the
+# Homebrew formula always tracks the latest release instead of a pinned version.
+
+require "digest"
+
+version = ARGV[0]
+abort "usage: update-formula.rb <version>" if version.nil? || version.empty?
+version = version.sub(/\Av/, "")
+
+formula_path = File.expand_path("../Formula/meowmine.rb", __dir__)
+bin_dir = File.expand_path("../bin", __dir__)
+
+binaries = %w[
+  meowmine-darwin-arm64
+  meowmine-ssh-darwin-arm64
+  meowmine-darwin-amd64
+  meowmine-ssh-darwin-amd64
+  meowmine-linux-amd64
+  meowmine-ssh-linux-amd64
+]
+
+shas = binaries.to_h do |name|
+  path = File.join(bin_dir, name)
+  abort "missing binary: #{path}" unless File.exist?(path)
+  [name, Digest::SHA256.file(path).hexdigest]
+end
+
+content = File.read(formula_path)
+content.sub!(/^(\s*version )"[^"]*"/, "\\1\"#{version}\"")
+
+binaries.each do |name|
+  pattern = /(url "\#\{base\}\/#{Regexp.escape(name)}"\s*\n\s*sha256 ")[0-9a-f]{64}(")/
+  unless content.sub!(pattern, "\\1#{shas[name]}\\2")
+    abort "could not find sha256 line for #{name} in formula"
+  end
+end
+
+File.write(formula_path, content)
+puts "Updated #{formula_path} to version #{version}"


### PR DESCRIPTION
## Summary
- Formula was pinned to `v0.1.0` with hardcoded sha256s — every release would need a manual edit
- `Formula/meowmine.rb` now derives the download URL from `#{version}` so the tag in the URL tracks the version field automatically
- New `scripts/update-formula.rb` hashes the freshly-built binaries in `bin/` and rewrites the formula's `version` plus all 6 sha256 lines (idempotent)
- `release.yml` runs the script on `main` after publishing and pushes the bump commit

Next tag push will update the formula itself — no manual bump needed.

## Test plan
- [x] Ran `scripts/update-formula.rb 0.2.0` against a fixture with fake binaries — version + all 6 sha256s rewritten correctly
- [x] Re-ran with the same version — no diff (idempotent)
- [ ] First real tag push (e.g. `v0.2.0`) lands both the GitHub release and a follow-up `chore: bump formula to v0.2.0` commit on `main`