### PR TITLE
chore: add gen-image asset generation skill

### DIFF
--- a/.claude/skills/gen-image/SKILL.md
+++ b/.claude/skills/gen-image/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: gen-image
+description: |
+  Generate asset/texture images for this project via OpenRouter's
+  openai/gpt-5.4-image-2 model. Use when the user asks to generate, create,
+  draft, or regenerate art, sprites, icons, textures, UI assets, or any
+  image from a text prompt. Saves files into the project's assets directory.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+
+# gen-image: asset image generator
+
+Calls `openai/gpt-5.4-image-2` via OpenRouter using the local
+`OPENROUTER_API_KEY`. Saves PNGs into `assets/generated/` by default.
+
+## Preflight
+
+```bash
+test -n "$OPENROUTER_API_KEY" && echo OK || echo "MISSING OPENROUTER_API_KEY"
+command -v python3 >/dev/null && echo PY_OK || echo "MISSING python3"
+```
+
+If `OPENROUTER_API_KEY` is missing, stop and ask the user to export it
+(`export OPENROUTER_API_KEY=sk-or-...`) before retrying. Do not hard-code
+the key into any file.
+
+## Usage
+
+Invoke the script from the project root:
+
+```bash
+python3 .claude/skills/gen-image/scripts/generate.py \
+  --prompt "pixel-art kitten miner holding a pickaxe, 32x32, transparent bg" \
+  -n 4 \
+  --size 1024x1024 \
+  --output-dir assets/generated/kitten-miner
+```
+
+Flags:
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--prompt` | (required) | Text prompt for the image |
+| `-n, --num` | `1` | How many images to generate (one API call per image) |
+| `-o, --output-dir` | `assets/generated` | Directory to write files into (created if missing) |
+| `--name` | slug of prompt | Base filename |
+| `--size` | model default | e.g. `512x512`, `1024x1024`, `1536x1024` |
+| `--quality` | model default | `low` / `medium` / `high` |
+| `--model` | `openai/gpt-5.4-image-2` | Override model id |
+| `--dry-run` | off | Print request payload without calling API |
+
+Files are named `<base>-<timestamp>-<NN>.<ext>`. If the model returns
+multiple images in one response, they are suffixed `-1`, `-2`, ...
+
+## Choosing `n`
+
+- Exploring a new concept: start with `-n 4` to compare variants.
+- Refining a locked design: `-n 1` or `-n 2` per iteration.
+- Batch generating matching assets (e.g. a set of icons): issue one
+  call per asset with distinct prompts, not a single `-n 10` blob.
+
+Each image is a separate API call, so cost scales linearly with `n`.
+
+## Output conventions
+
+- Project-root-relative output paths only (stay inside `assets/`).
+- Do not commit generated images unless the user asks.
+- If the response contains no image (content policy, rate limit, etc.),
+  the raw JSON is saved next to the expected filename for debugging.
+
+## After generating
+
+Read the file back with the Read tool so the user can see it:
+
+```
+Read({file_path: "/absolute/path/to/assets/generated/...png"})
+```
+
+Show all generated files this way before reporting `DONE`.
+
+## When to use this skill
+
+- "generate a sprite for X"
+- "draft some concept art for the mine background"
+- "make 4 icon variants for the upgrade button"
+- "regenerate the title screen art"
+
+## When NOT to use
+
+- Editing/compositing existing images (this skill only generates from prompts).
+- Vector / SVG output (model returns raster).
+- Anything requiring reference images — current script is text-prompt only.

--- a/.claude/skills/gen-image/scripts/generate.py
+++ b/.claude/skills/gen-image/scripts/generate.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Generate asset images via OpenRouter (openai/gpt-5.4-image-2).
+
+Reads OPENROUTER_API_KEY from env. Saves images to --output-dir.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+API_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_MODEL = "openai/gpt-5.4-image-2"
+
+
+def slugify(text: str, max_len: int = 40) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return (s[:max_len] or "image").rstrip("-")
+
+
+def build_payload(model: str, prompt: str, size: str | None, quality: str | None) -> dict:
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "modalities": ["image", "text"],
+    }
+    if size or quality:
+        img_opts = {}
+        if size:
+            img_opts["size"] = size
+        if quality:
+            img_opts["quality"] = quality
+        payload["image"] = img_opts
+    return payload
+
+
+def call_api(payload: dict, api_key: str, timeout: int = 180) -> dict:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        API_URL,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/local/kitten-crypto-mining-ventures",
+            "X-Title": "kitten-crypto-mining-ventures asset gen",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"HTTP {e.code}: {body}") from e
+
+
+def extract_images(resp: dict) -> list[tuple[str, bytes]]:
+    """Extract (extension, bytes) for each image in the response.
+
+    Handles multiple OpenRouter response shapes:
+    - message.images[].image_url.url (data URL or http URL)
+    - message.content as list with {"type": "image_url", "image_url": ...}
+    - message.content as list with {"type": "output_image", "image": "<b64>"}
+    """
+    out: list[tuple[str, bytes]] = []
+    choices = resp.get("choices") or []
+    for choice in choices:
+        msg = choice.get("message") or {}
+        for item in msg.get("images") or []:
+            url = (item.get("image_url") or {}).get("url") if isinstance(item.get("image_url"), dict) else item.get("image_url")
+            if url:
+                out.append(decode_image(url))
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                t = part.get("type")
+                if t in ("image_url", "image"):
+                    url_obj = part.get("image_url") or part.get("image") or {}
+                    url = url_obj.get("url") if isinstance(url_obj, dict) else url_obj
+                    if url:
+                        out.append(decode_image(url))
+                elif t in ("output_image", "image_base64"):
+                    b64 = part.get("image") or part.get("data") or part.get("b64_json")
+                    if b64:
+                        out.append(("png", base64.b64decode(b64)))
+    return out
+
+
+def decode_image(url: str) -> tuple[str, bytes]:
+    if url.startswith("data:"):
+        header, _, b64 = url.partition(",")
+        ext = "png"
+        m = re.match(r"data:image/([a-zA-Z0-9+]+)", header)
+        if m:
+            ext = m.group(1).replace("jpeg", "jpg")
+        return ext, base64.b64decode(b64)
+    # remote URL — fetch it
+    with urllib.request.urlopen(url, timeout=60) as r:
+        ext = "png"
+        ctype = r.headers.get("content-type", "")
+        m = re.search(r"image/([a-zA-Z0-9+]+)", ctype)
+        if m:
+            ext = m.group(1).replace("jpeg", "jpg")
+        return ext, r.read()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Generate asset images via OpenRouter.")
+    p.add_argument("--prompt", required=True, help="Image prompt")
+    p.add_argument("-n", "--num", type=int, default=1, help="Number of images (separate API calls)")
+    p.add_argument("-o", "--output-dir", default="assets/generated", help="Output directory")
+    p.add_argument("--name", default=None, help="Base filename (defaults to slug of prompt)")
+    p.add_argument("--size", default=None, help="Image size, e.g. 1024x1024")
+    p.add_argument("--quality", default=None, help="Image quality: low | medium | high")
+    p.add_argument("--model", default=DEFAULT_MODEL, help="OpenRouter model id")
+    p.add_argument("--dry-run", action="store_true", help="Print payload and exit")
+    args = p.parse_args()
+
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key and not args.dry_run:
+        print("ERROR: OPENROUTER_API_KEY is not set in the environment.", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base_name = args.name or slugify(args.prompt)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+
+    payload = build_payload(args.model, args.prompt, args.size, args.quality)
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    saved: list[str] = []
+    for i in range(1, args.num + 1):
+        print(f"[{i}/{args.num}] requesting...", file=sys.stderr)
+        resp = call_api(payload, api_key)
+        images = extract_images(resp)
+        if not images:
+            debug_path = out_dir / f"{base_name}-{ts}-{i:02d}.response.json"
+            debug_path.write_text(json.dumps(resp, indent=2))
+            print(f"  no image in response — raw saved to {debug_path}", file=sys.stderr)
+            continue
+        for j, (ext, data) in enumerate(images, start=1):
+            suffix = f"-{j}" if len(images) > 1 else ""
+            path = out_dir / f"{base_name}-{ts}-{i:02d}{suffix}.{ext}"
+            path.write_bytes(data)
+            saved.append(str(path))
+            print(f"  saved {path} ({len(data)} bytes)", file=sys.stderr)
+
+    print("\n".join(saved))
+    return 0 if saved else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ Thumbs.db
 # Workspace
 .worktrees/
 .autonomous/
-.claude/
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
## Summary

Adds a project-local Claude Code skill (`.claude/skills/gen-image/`) that generates asset images via OpenRouter's `openai/gpt-5.4-image-2` model using the local `OPENROUTER_API_KEY`.

- `SKILL.md` — skill description, usage, flags, when-to-use
- `scripts/generate.py` — Python stdlib only; no pip deps
- `.gitignore` — carves out `.claude/skills/` from the `.claude/` ignore so the skill ships with the repo while personal harness state stays local

## Usage

```bash
export OPENROUTER_API_KEY=sk-or-...
python3 .claude/skills/gen-image/scripts/generate.py \
  --prompt "pixel-art kitten miner holding a pickaxe, transparent bg" \
  -n 4 --size 1024x1024 \
  --output-dir assets/generated/kitten-miner
```

Flags: `--prompt` (req), `-n` count, `-o` output dir, `--name`, `--size`, `--quality`, `--model`, `--dry-run`.

One API call per image. If a response contains no image (rate limit, content policy, etc.), the raw JSON is dumped next to the expected filename for debugging. Parses multiple OpenRouter response shapes (`message.images`, content parts, data URLs, remote URLs).

## Test plan

- [x] Python syntax parses
- [x] `--dry-run` prints expected payload
- [ ] Live call saves an image with real `OPENROUTER_API_KEY` (do locally, don't block merge)