### PR TITLE
fix: cap LastWagesUnix on offline catch-up

### DIFF
--- a/cmd/meowmine-ssh/main.go
+++ b/cmd/meowmine-ssh/main.go
@@ -93,6 +93,7 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 		if gap := now - state.LastTickUnix; gap > 8*3600 {
 			state.LastTickUnix = now - 8*3600
 			state.LastBillUnix = now - 8*3600
+			state.LastWagesUnix = now - 8*3600
 		}
 		state.Tick(now)
 	}

--- a/cmd/meowmine/main.go
+++ b/cmd/meowmine/main.go
@@ -41,6 +41,7 @@ func main() {
 			gap = 8 * 3600
 			state.LastTickUnix = now - gap
 			state.LastBillUnix = now - gap
+			state.LastWagesUnix = now - gap
 			state.AppendLog("info", "Offline > 8h — capped progress at 8 hours.")
 		}
 		if gap > 60 {


### PR DESCRIPTION
## Summary

- `cmd/meowmine/main.go` and `cmd/meowmine-ssh/main.go` clamp `LastTickUnix` and `LastBillUnix` to `now - 8h` when a save is older than 8 hours, but **forgot `LastWagesUnix`**.
- After a multi-day absence, the next tick calls `payWages()` with `weeks := (now - LastWagesUnix) / 3600`, so a 14-day-old save charges ~336 weeks of wages in a single frame — either wiping the player's cash to zero or drifting every merc's loyalty down by 10 (cascading betrayals).
- Two-line fix: add `state.LastWagesUnix = now - 8*3600` to both catch-up sites. Restores the "capped at 8h" promise in the README.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Hand-verify: set save `last_wages_unix` to a timestamp >8h old, relaunch, confirm wages charge at most 8h worth.