### PR TITLE
refactor: collapse Money + BTC into single BTC currency

### DIFF
--- a/core/data/data_test.go
+++ b/core/data/data_test.go
@@ -64,7 +64,7 @@ func TestEventsValid(t *testing.T) {
 	}
 	validKinds := map[string]bool{
 		"steal_gpu": true, "pause_mining": true, "rep_change": true,
-		"tech_point": true, "gift_gpu": true, "btc_multiplier": true,
+		"tech_point": true, "gift_gpu": true,
 		"earn_multiplier": true, "damage_gpu": true, "burn_room_chance": true,
 		"eviction_warning": true, "money_loss": true,
 	}

--- a/core/data/events.json
+++ b/core/data/events.json
@@ -65,11 +65,11 @@
     "name_zh": "BTC 拉盘",
     "category": "opportunity",
     "emoji": "🎉",
-    "text": "Somewhere, a tweet fires. BTC rockets for the next few minutes.",
-    "text_zh": "某处一条推文爆了。BTC 接下来几分钟一飞冲天。",
+    "text": "Somewhere, a tweet fires. The whole market surges — your rigs cash in harder for a few minutes.",
+    "text_zh": "某处一条推文爆了。全场涨价，接下来几分钟产出大涨。",
     "weight": 4,
     "cooldown_sec": 1200,
-    "effects": [{"kind": "btc_multiplier", "factor": 1.5, "seconds": 300}]
+    "effects": [{"kind": "earn_multiplier", "factor": 1.5, "seconds": 300}]
   },
   {
     "id": "lucky_fish",
@@ -223,9 +223,21 @@
     "weight": 1,
     "cooldown_sec": 72000,
     "effects": [
-      {"kind": "btc_multiplier", "factor": 1.4, "seconds": 1800},
+      {"kind": "earn_multiplier", "factor": 1.4, "seconds": 1800},
       {"kind": "earn_multiplier", "factor": 1.2, "seconds": 10800}
     ]
+  },
+  {
+    "id": "voltage_dip",
+    "name": "Voltage Dip",
+    "name_zh": "电压不稳",
+    "category": "threat",
+    "emoji": "⚡",
+    "text": "The mains sag. Every rig throttles for a while.",
+    "text_zh": "电压拉跨，所有机器被迫降频。",
+    "weight": 3,
+    "cooldown_sec": 1500,
+    "effects": [{"kind": "earn_multiplier", "factor": 0.6, "seconds": 300}]
   },
   {
     "id": "polar_bear",

--- a/core/data/skills.go
+++ b/core/data/skills.go
@@ -4,7 +4,7 @@ import "github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 
 // SkillEffect describes what a skill changes when unlocked.
 type SkillEffect struct {
-	Kind    string  // power_mult, bill_mult, scrap_mult, btc_damp, repair_free, merc_loyalty, unlock
+	Kind    string  // power_mult, bill_mult, scrap_mult, earn_damp, repair_free, merc_loyalty, unlock
 	Value   float64 // multiplier or delta, depending on Kind
 	Unlocks string  // feature gate (e.g. "rd", "prestige", "pump_dump_action")
 }
@@ -63,11 +63,11 @@ var skillDefs = []SkillDef{
 		NameZH: "税务优化",
 		Desc:   "Scrap / sell value +20%.",
 		DescZH: "拆解/出售价值 +20%。"},
-	{ID: "hedged_wallet", Lane: "mogul", Cost: 6, Prereq: "smart_invoicing", Effect: SkillEffect{Kind: "btc_damp", Value: 0.50},
+	{ID: "hedged_wallet", Lane: "mogul", Cost: 6, Prereq: "smart_invoicing", Effect: SkillEffect{Kind: "earn_damp", Value: 0.50},
 		Name:   "Hedged Wallet",
 		NameZH: "对冲钱包",
-		Desc:   "BTC volatility halved.",
-		DescZH: "BTC 价格波动减半。"},
+		Desc:   "Event earn-rate swings halved (both ways).",
+		DescZH: "事件带来的产出波动减半（上下皆减）。"},
 	{ID: "venture_cap", Lane: "mogul", Cost: 12, Prereq: "hedged_wallet", Effect: SkillEffect{Kind: "unlock", Unlocks: "prestige"},
 		Name:   "Venture Capital",
 		NameZH: "风险投资",
@@ -83,8 +83,8 @@ var skillDefs = []SkillDef{
 	{ID: "pump_dump", Lane: "hacker", Cost: 6, Effect: SkillEffect{Kind: "unlock", Unlocks: "pump_dump_action"},
 		Name:   "Pump & Dump",
 		NameZH: "拉盘砸盘",
-		Desc:   "Manually trigger a BTC pump (cooldown).",
-		DescZH: "手动触发 BTC 拉盘（有冷却）。"},
+		Desc:   "Manually trigger a ×1.5 mining boost (5 min, 30 min cooldown).",
+		DescZH: "手动触发 ×1.5 产出加成（5 分钟，冷却 30 分钟）。"},
 	{ID: "chain_ghost", Lane: "hacker", Cost: 12, Prereq: "pump_dump", Effect: SkillEffect{Kind: "merc_loyalty", Value: 15},
 		Name:   "Chain Ghost",
 		NameZH: "链上幽灵",

--- a/core/game/economy.go
+++ b/core/game/economy.go
@@ -1,21 +1,11 @@
 package game
 
-import (
-	"math"
-	"time"
-)
-
-// BTCBasePrice is the centre of the random walk. Intentionally set low
-// (not matching real-world BTC) to stretch the progression curve:
-//
-//	1 GTX 1060 at 0.0012 BTC/s × $300 = $0.36/s, so a second 1060 ($120)
-//	pays for itself in ~5 minutes. An A100 ($60k) in ~80 minutes of
-//	dedicated uptime. This matches typical idle-game pacing (Adventure
-//	Capitalist / Kittens Game / NGU Idle) where mid-tier unlocks land
-//	every 15-30 min and endgame milestones take multi-hour sessions.
-//
-// Lore: the kittens mine an obscure altcoin, not real BTC.
-const BTCBasePrice = 300.0
+// MiningScale converts raw GPU efficiency (the pre-unification BTC/sec rate)
+// into the balance-scale BTC units shown in the UI. Tuned so a GTX 1060
+// (eff 0.0012) at scale 300 yields ₿0.36/sec — a 1060 pays back in ~5 min,
+// an A100 (₿60k) in ~80 min of dedicated uptime. Numbers preserved from
+// the earlier USD-priced economy so difficulty curves stay intact.
+const MiningScale = 300.0
 
 // ElectricPerVoltMin is the per-V per-minute price of electricity. Rooms
 // multiply this by their electric_cost_mult. Tuned so bills are ~5-10% of
@@ -23,37 +13,8 @@ const BTCBasePrice = 300.0
 // unless you run an oversubscribed rack.
 const ElectricPerVoltMin = 0.25
 
-// BTCPriceAt computes the BTC price at a given unix second using a seeded
-// double-sine oscillator + any active event multipliers. Deterministic per
-// seed+time so the UI can render a graph without storing history.
-func (s *State) BTCPriceAt(t int64) float64 {
-	// Long wave: ~10 min period, ±10%
-	long := math.Sin(float64(t-s.StartedUnix)*2.0*math.Pi/600.0) * 0.10
-	// Short wave: ~30 sec period, ±3%
-	short := math.Sin(float64(t-s.StartedUnix)*2.0*math.Pi/30.0) * 0.03
-	// Seeded medium wave (personalises the curve per save).
-	mseed := float64(s.BTCPriceSeed%1_000_000) / 1_000_000.0
-	medium := math.Sin(float64(t-s.StartedUnix)*2.0*math.Pi/180.0+mseed*2*math.Pi) * 0.05
-	price := BTCBasePrice * (1.0 + long + short + medium)
-	// News multiplier.
-	for _, m := range s.Modifiers {
-		if m.Kind == "btc_mult" && m.ExpiresAt > t {
-			price *= m.Factor
-		}
-	}
-	if price < 500 {
-		price = 500
-	}
-	return price
-}
-
-// CurrentBTCPrice is convenience for BTCPriceAt(now).
-func (s *State) CurrentBTCPrice() float64 {
-	return s.BTCPriceAt(time.Now().Unix())
-}
-
-// earnMultiplier returns the aggregate positive-production multiplier from
-// active modifiers.
+// earnMultiplier returns the aggregate production multiplier from active
+// time-limited modifiers (events, skill actions).
 func (s *State) earnMultiplier(now int64) float64 {
 	mult := 1.0
 	for _, m := range s.Modifiers {

--- a/core/game/economy_test.go
+++ b/core/game/economy_test.go
@@ -1,71 +1,27 @@
 package game
 
 import (
-	"math"
 	"testing"
 	"time"
 )
 
-func TestBTCPriceStaysPositive(t *testing.T) {
-	withTempHome(t)
-	s := NewState("BTC")
-	// Sample many points along the oscillator.
-	for i := int64(0); i < 7200; i += 17 {
-		p := s.BTCPriceAt(s.StartedUnix + i)
-		if p <= 0 {
-			t.Fatalf("BTC price went non-positive at t+%d: %.2f", i, p)
-		}
-		if math.IsNaN(p) || math.IsInf(p, 0) {
-			t.Fatalf("BTC price went non-finite at t+%d", i)
-		}
-	}
-}
-
-func TestBTCPriceDeterministicPerSeed(t *testing.T) {
-	withTempHome(t)
-	s := NewState("Det")
-	p1 := s.BTCPriceAt(s.StartedUnix + 300)
-	p2 := s.BTCPriceAt(s.StartedUnix + 300)
-	if p1 != p2 {
-		t.Errorf("BTCPriceAt not deterministic: %.2f vs %.2f", p1, p2)
-	}
-}
-
-func TestBTCPriceRespondsToMultiplier(t *testing.T) {
-	withTempHome(t)
-	s := NewState("Mult")
-	now := time.Now().Unix()
-	base := s.BTCPriceAt(now)
-	s.Modifiers = append(s.Modifiers, Modifier{
-		Kind:      "btc_mult",
-		Factor:    2.0,
-		ExpiresAt: now + 3600,
-	})
-	bumped := s.BTCPriceAt(now)
-	if bumped <= base {
-		t.Errorf("btc_mult factor 2.0 should raise price: base=%.2f bumped=%.2f", base, bumped)
-	}
-}
-
 func TestTickAccruesBTCAndBills(t *testing.T) {
 	withTempHome(t)
 	s := NewState("TickFlow")
-	// Force starter into running state right now so advanceMining produces.
 	for _, g := range s.GPUs {
 		g.Status = "running"
 	}
-	startMoney := s.Money
-	s.LastTickUnix = time.Now().Unix() - 120 // 2 minutes of dt
+	startBTC := s.BTC
+	s.LastTickUnix = time.Now().Unix() - 120
 	s.LastBillUnix = time.Now().Unix() - 120
 	s.Tick(time.Now().Unix())
-	// After 2 minutes the starter should have earned some money and paid a bill.
-	if s.Money <= 0 {
+	if s.BTC <= 0 {
 		t.Error("tick bankrupted the player inexplicably")
 	}
 	if s.LifetimeEarned <= 0 {
 		t.Error("LifetimeEarned should accumulate on earnings")
 	}
-	_ = startMoney // not strictly compared — just ensure no panic
+	_ = startBTC
 }
 
 func TestModifiersExpireOnTick(t *testing.T) {
@@ -73,33 +29,26 @@ func TestModifiersExpireOnTick(t *testing.T) {
 	s := NewState("Expire")
 	past := time.Now().Unix() - 10
 	s.Modifiers = []Modifier{
-		{Kind: "btc_mult", Factor: 1.5, ExpiresAt: past},
+		{Kind: "earn_mult", Factor: 1.5, ExpiresAt: past},
 		{Kind: "earn_mult", Factor: 1.2, ExpiresAt: time.Now().Unix() + 3600},
 	}
 	s.LastTickUnix = time.Now().Unix() - 1
 	s.Tick(time.Now().Unix())
-	kinds := map[string]int{}
-	for _, m := range s.Modifiers {
-		kinds[m.Kind]++
+	if len(s.Modifiers) != 1 {
+		t.Fatalf("expected exactly one modifier after prune, got %d", len(s.Modifiers))
 	}
-	if kinds["btc_mult"] != 0 {
-		t.Error("expired btc_mult should be pruned")
-	}
-	if kinds["earn_mult"] != 1 {
-		t.Error("still-valid earn_mult should survive")
+	if s.Modifiers[0].Factor != 1.2 {
+		t.Error("expected the still-valid earn_mult (factor 1.2) to survive")
 	}
 }
 
 func TestBlackoutWhenBroke(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Bankrupt")
-	s.Money = 0
-	// Put some power-hungry GPUs up so the bill is real.
+	s.BTC = 0
 	for i := 0; i < 4; i++ {
 		s.addGPU("rtx4090", "alley", false)
 	}
-	// Bypass Tick so BTC auto-cash-out doesn't secretly cover the bill —
-	// we're testing the billing path specifically.
 	now := time.Now().Unix()
 	s.LastBillUnix = now - 70
 	s.advanceBilling(now)

--- a/core/game/events.go
+++ b/core/game/events.go
@@ -20,6 +20,7 @@ func (s *State) MaybeFireEvent() *data.EventDef {
 	globalPool := []string{
 		"tech_share", "extra_delivery", "btc_pump", "lucky_fish",
 		"group_chat_sos", "celeb_interview", "halving", "police_visit",
+		"voltage_dip",
 	}
 	all := append([]string{}, pool...)
 	all = append(all, globalPool...)
@@ -136,25 +137,20 @@ func (s *State) applyEvent(e data.EventDef) {
 				}
 			} else {
 				if def, ok := data.GPUByID(candidate); ok {
-					s.Money += float64(def.ScrapValue) * s.ScrapValueMult()
-					s.appendLog("info", fmt.Sprintf("…but no room. Sold %s for cash.", def.Name))
+					s.BTC += float64(def.ScrapValue) * s.ScrapValueMult()
+					s.appendLog("info", fmt.Sprintf("…but no room. Sold %s for scrap.", def.Name))
 				}
 			}
-		case "btc_multiplier":
-			// Hedged wallet dampens the swing toward 1.0.
+		case "earn_multiplier":
+			// Hedged Wallet softens earn-rate swings (both positive and
+			// negative) back toward 1.0.
 			factor := eff.Factor
-			if damp := s.BTCVolatilityDamp(); damp < 1.0 {
+			if damp := s.EarnVolatilityDamp(); damp < 1.0 {
 				factor = 1.0 + (factor-1.0)*damp
 			}
 			s.Modifiers = append(s.Modifiers, Modifier{
-				Kind:      "btc_mult",
-				Factor:    factor,
-				ExpiresAt: now + int64(eff.Seconds),
-			})
-		case "earn_multiplier":
-			s.Modifiers = append(s.Modifiers, Modifier{
 				Kind:      "earn_mult",
-				Factor:    eff.Factor,
+				Factor:    factor,
 				ExpiresAt: now + int64(eff.Seconds),
 			})
 		case "damage_gpu":
@@ -181,12 +177,12 @@ func (s *State) applyEvent(e data.EventDef) {
 			if frac <= 0 {
 				frac = 0.1
 			}
-			loss := s.Money * frac
-			s.Money -= loss
-			if s.Money < 0 {
-				s.Money = 0
+			loss := s.BTC * frac
+			s.BTC -= loss
+			if s.BTC < 0 {
+				s.BTC = 0
 			}
-			s.appendLog("threat", fmt.Sprintf("💸 Lost $%.0f (%.0f%% of cash).", loss, frac*100))
+			s.appendLog("threat", fmt.Sprintf("💸 Lost ₿%.0f (%.0f%% of balance).", loss, frac*100))
 		}
 	}
 }
@@ -291,17 +287,17 @@ func (s *State) RepairGPU(instanceID int) error {
 		if s.RepairFree() {
 			cost = 0
 		}
-		if s.Money < float64(cost) {
-			return fmt.Errorf("need $%d to repair", cost)
+		if s.BTC < float64(cost) {
+			return fmt.Errorf("need ₿%d to repair", cost)
 		}
-		s.Money -= float64(cost)
+		s.BTC -= float64(cost)
 		g.Status = "running"
 		_, _, _, dur := s.GPUStats(g)
 		g.HoursLeft = dur * 0.6
 		if cost == 0 {
 			s.appendLog("info", "🔧 PCB surgery — free repair.")
 		} else {
-			s.appendLog("info", fmt.Sprintf("🔧 Repaired for $%d.", cost))
+			s.appendLog("info", fmt.Sprintf("🔧 Repaired for ₿%d.", cost))
 		}
 		return nil
 	}

--- a/core/game/greed.go
+++ b/core/game/greed.go
@@ -13,8 +13,8 @@ func (s *State) GreedScore() float64 {
 	if s.LifetimeEarned < 1 {
 		return 0
 	}
-	// Fraction of lifetime money that's sitting liquid.
-	liquid := s.Money / s.LifetimeEarned
+	// Fraction of lifetime earnings that's sitting liquid right now.
+	liquid := s.BTC / s.LifetimeEarned
 	if liquid > 1 {
 		liquid = 1
 	}

--- a/core/game/mercs.go
+++ b/core/game/mercs.go
@@ -14,10 +14,10 @@ func (s *State) HireMerc(defID string) error {
 	if !ok {
 		return fmt.Errorf("unknown merc")
 	}
-	if s.Money < float64(def.HireCost) {
-		return fmt.Errorf("need $%d, have $%.0f", def.HireCost, s.Money)
+	if s.BTC < float64(def.HireCost) {
+		return fmt.Errorf("need ₿%d, have ₿%.0f", def.HireCost, s.BTC)
 	}
-	s.Money -= float64(def.HireCost)
+	s.BTC -= float64(def.HireCost)
 	loyalty := def.LoyaltyBase + s.MercLoyaltyFloor()
 	if loyalty > 100 {
 		loyalty = 100
@@ -31,7 +31,7 @@ func (s *State) HireMerc(defID string) error {
 	}
 	s.NextMercID++
 	s.Mercs = append(s.Mercs, m)
-	s.appendLog("info", fmt.Sprintf("🐾 Hired %s for $%d.", def.Name, def.HireCost))
+	s.appendLog("info", fmt.Sprintf("🐾 Hired %s for ₿%d.", def.Name, def.HireCost))
 	return nil
 }
 
@@ -51,15 +51,15 @@ func (s *State) FireMerc(instanceID int) error {
 	return fmt.Errorf("no such merc")
 }
 
-// BribeMerc spends $200 for +15 loyalty.
+// BribeMerc spends ₿200 for +15 loyalty.
 func (s *State) BribeMerc(instanceID int) error {
 	const cost = 200
-	if s.Money < cost {
-		return fmt.Errorf("need $%d", cost)
+	if s.BTC < cost {
+		return fmt.Errorf("need ₿%d", cost)
 	}
 	for _, m := range s.Mercs {
 		if m.InstanceID == instanceID {
-			s.Money -= cost
+			s.BTC -= cost
 			m.Loyalty += 15
 			if m.Loyalty > 100 {
 				m.Loyalty = 100
@@ -90,12 +90,12 @@ func (s *State) payWages(now int64) {
 		wage := float64(def.WeeklyWage) * weeks
 		totalWage += wage
 		// Loyalty drift: +1 per week on time, or −10 if we can't afford.
-		if s.Money >= wage {
-			s.Money -= wage
+		if s.BTC >= wage {
+			s.BTC -= wage
 			m.Loyalty++
 		} else {
 			// Missed wages — loyalty tanks, wage still banked as debt-reduction.
-			s.Money = 0
+			s.BTC = 0
 			m.Loyalty -= 10
 		}
 		if m.Loyalty > 100 {
@@ -106,7 +106,7 @@ func (s *State) payWages(now int64) {
 		}
 	}
 	if totalWage > 0 {
-		s.appendLog("info", fmt.Sprintf("💼 Paid $%.2f in mercenary wages.", totalWage))
+		s.appendLog("info", fmt.Sprintf("💼 Paid ₿%.2f in mercenary wages.", totalWage))
 	}
 
 	// Random betrayal check — once per wage tick, one low-loyalty merc might flip.

--- a/core/game/prestige.go
+++ b/core/game/prestige.go
@@ -24,7 +24,7 @@ type LegacyPerk struct {
 var legacyPerks = []LegacyPerk{
 	{
 		ID: "starter_cash_500", Name: "Seed Capital", Cost: 10,
-		Desc: "Start new runs with an extra $500.",
+		Desc: "Start new runs with an extra ₿500.",
 		ApplyOnBuy: func(l *LegacyStore) { l.StarterCash += 500 },
 		Available:  func(l *LegacyStore) bool { return l.StarterCash < 5000 },
 	},
@@ -61,7 +61,7 @@ func (s *State) RetireReward() int {
 // Returns the NEW state (to swap in) and the LP awarded.
 func (s *State) Retire() (*State, int, error) {
 	if !s.CanRetire() {
-		return nil, 0, fmt.Errorf("need $%.0f lifetime earnings; have $%.0f", PrestigeThreshold, s.LifetimeEarned)
+		return nil, 0, fmt.Errorf("need ₿%.0f lifetime earnings; have ₿%.0f", PrestigeThreshold, s.LifetimeEarned)
 	}
 	lp := s.RetireReward()
 	legacy := LoadLegacy()

--- a/core/game/research.go
+++ b/core/game/research.go
@@ -56,11 +56,11 @@ func (s *State) StartResearch(tier int, boosts []string) error {
 	if s.ResearchFrags < info.Frags {
 		return fmt.Errorf("need %d research fragments, have %d", info.Frags, s.ResearchFrags)
 	}
-	if s.Money < float64(info.Money) {
-		return fmt.Errorf("need $%d, have $%.0f", info.Money, s.Money)
+	if s.BTC < float64(info.Money) {
+		return fmt.Errorf("need ₿%d, have ₿%.0f", info.Money, s.BTC)
 	}
 	s.ResearchFrags -= info.Frags
-	s.Money -= float64(info.Money)
+	s.BTC -= float64(info.Money)
 	s.ActiveResearch = &Research{
 		BlueprintTier: tier,
 		Boosts:        append([]string{}, boosts...),
@@ -139,8 +139,8 @@ func (s *State) PrintMEOWCore(blueprintID string) error {
 	}
 	cost := info.Money * 3 / 10
 	frags := info.Frags / 5
-	if s.Money < float64(cost) {
-		return fmt.Errorf("need $%d to print", cost)
+	if s.BTC < float64(cost) {
+		return fmt.Errorf("need ₿%d to print", cost)
 	}
 	if s.ResearchFrags < frags {
 		return fmt.Errorf("need %d fragments to print", frags)
@@ -148,7 +148,7 @@ func (s *State) PrintMEOWCore(blueprintID string) error {
 	if !s.RoomHasFreeSlot(s.CurrentRoom) {
 		return fmt.Errorf("no free slot in this room")
 	}
-	s.Money -= float64(cost)
+	s.BTC -= float64(cost)
 	s.ResearchFrags -= frags
 	s.addMEOWCore(bp, s.CurrentRoom)
 	s.appendLog("opportunity", fmt.Sprintf("🛠 Printed a %s (%s).", bpName(bp.Tier), joinStrs(bp.Boosts)))

--- a/core/game/research_test.go
+++ b/core/game/research_test.go
@@ -8,7 +8,7 @@ import (
 func TestStartResearchLockedByDefault(t *testing.T) {
 	withTempHome(t)
 	s := NewState("NoRD")
-	s.Money = 99999
+	s.BTC = 99999
 	s.ResearchFrags = 999
 	if err := s.StartResearch(1, []string{"efficiency", "undervolt"}); err == nil {
 		t.Error("should be gated behind rd unlock")
@@ -63,7 +63,7 @@ func TestPrintMEOWCoreConsumesResources(t *testing.T) {
 		ID: "bp_test", Tier: 1, Boosts: []string{"efficiency", "undervolt"},
 	})
 	// Give resources; ensure alley has room (start has 1 GPU, 4 slots).
-	s.Money = 10000
+	s.BTC = 10000
 	s.ResearchFrags = 100
 	before := len(s.GPUs)
 	if err := s.PrintMEOWCore("bp_test"); err != nil {
@@ -117,7 +117,7 @@ func TestRetireProducesFreshStateAndLP(t *testing.T) {
 	_ = s.UnlockSkill("hedged_wallet")
 	_ = s.UnlockSkill("venture_cap")
 	s.LifetimeEarned = 4_000_000
-	s.Money = 5000
+	s.BTC = 5000
 	fresh, lp, err := s.Retire()
 	if err != nil {
 		t.Fatalf("retire: %v", err)
@@ -147,7 +147,7 @@ func unlockRDFixture(t *testing.T) *State {
 	_ = s.UnlockSkill("undervolt_i")
 	_ = s.UnlockSkill("undervolt_ii")
 	_ = s.UnlockSkill("rd_unlock")
-	s.Money = 99999
+	s.BTC = 99999
 	s.ResearchFrags = 999
 	return s
 }

--- a/core/game/skills.go
+++ b/core/game/skills.go
@@ -128,11 +128,12 @@ func (s *State) MercLoyaltyFloor() int {
 	return floor
 }
 
-// BTCVolatilityDamp returns a 0..1 factor that dampens price swings (1.0 = no damp).
-func (s *State) BTCVolatilityDamp() float64 {
+// EarnVolatilityDamp returns a 0..1 factor that dampens earn-multiplier
+// swings (1.0 = no damp). Hedged Wallet cuts event-driven volatility in half.
+func (s *State) EarnVolatilityDamp() float64 {
 	damp := 1.0
 	for id := range s.UnlockedSkills {
-		if def, ok := data.SkillByID(id); ok && def.Effect.Kind == "btc_damp" {
+		if def, ok := data.SkillByID(id); ok && def.Effect.Kind == "earn_damp" {
 			damp *= def.Effect.Value
 		}
 	}

--- a/core/game/skills_test.go
+++ b/core/game/skills_test.go
@@ -58,11 +58,11 @@ func TestHasUnlockGatesResearch(t *testing.T) {
 func TestHireMercRequiresMoney(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Merc")
-	s.Money = 50
+	s.BTC = 50
 	if err := s.HireMerc("tabby_guard"); err == nil {
 		t.Error("should refuse hire without enough money")
 	}
-	s.Money = 2000
+	s.BTC = 2000
 	if err := s.HireMerc("tabby_guard"); err != nil {
 		t.Fatalf("hire: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestHireMercRequiresMoney(t *testing.T) {
 func TestBribeMercRaisesLoyalty(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Bribe")
-	s.Money = 5000
+	s.BTC = 5000
 	_ = s.HireMerc("tabby_guard")
 	m := s.Mercs[0]
 	m.Loyalty = 30
@@ -89,7 +89,7 @@ func TestBribeMercRaisesLoyalty(t *testing.T) {
 func TestFireMercLowersPeerLoyalty(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Fire")
-	s.Money = 10000
+	s.BTC = 10000
 	_ = s.HireMerc("tabby_guard")
 	_ = s.HireMerc("siamese_it")
 	peer := s.Mercs[1]
@@ -106,7 +106,7 @@ func TestFireMercLowersPeerLoyalty(t *testing.T) {
 func TestUpgradeDefenseIncrementsLevel(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Defense")
-	s.Money = 5000
+	s.BTC = 5000
 	if err := s.UpgradeDefense("lock"); err != nil {
 		t.Fatalf("upgrade lock: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestUpgradeDefenseIncrementsLevel(t *testing.T) {
 func TestUpgradeDefenseRejectsBadDim(t *testing.T) {
 	withTempHome(t)
 	s := NewState("DefenseBad")
-	s.Money = 99999
+	s.BTC = 99999
 	if err := s.UpgradeDefense("nonsense"); err == nil {
 		t.Error("should reject unknown dim")
 	}

--- a/core/game/state.go
+++ b/core/game/state.go
@@ -69,7 +69,7 @@ type Research struct {
 
 // Modifier is a time-limited multiplier or flag.
 type Modifier struct {
-	Kind      string  `json:"kind"`   // "btc_mult" | "earn_mult" | "pause_mining"
+	Kind      string  `json:"kind"`   // "earn_mult" | "pause_mining"
 	Factor    float64 `json:"factor"` // multiplier value; or unused for flags
 	ExpiresAt int64   `json:"expires_at"`
 }
@@ -88,9 +88,7 @@ type EventCooldowns map[string]int64
 type State struct {
 	Version       int                   `json:"version"`
 	KittenName    string                `json:"kitten_name"`
-	Money         float64               `json:"money"`
 	BTC           float64               `json:"btc"`
-	BTCPriceSeed  int64                 `json:"btc_price_seed"`
 	TechPoint     int                   `json:"tech_point"`
 	Reputation    int                   `json:"reputation"`
 	Karma         int                   `json:"karma"`
@@ -150,9 +148,7 @@ func newStateWithLegacy(kittenName string, legacy *LegacyStore) *State {
 	s := &State{
 		Version:        1,
 		KittenName:     kittenName,
-		Money:          150,
-		BTC:            0,
-		BTCPriceSeed:   rand.Int63(),
+		BTC:            150,
 		TechPoint:      0,
 		Reputation:     0,
 		Karma:          0,
@@ -193,8 +189,8 @@ func newStateWithLegacy(kittenName string, legacy *LegacyStore) *State {
 	// Apply legacy bonuses at start.
 	if legacy != nil {
 		if legacy.StarterCash > 0 {
-			s.Money += legacy.StarterCash
-			s.appendLog("opportunity", fmt.Sprintf("Legacy bonus: +$%.0f starter cash.", legacy.StarterCash))
+			s.BTC += legacy.StarterCash
+			s.appendLog("opportunity", fmt.Sprintf("Legacy bonus: +₿%.0f starter balance.", legacy.StarterCash))
 		}
 		if legacy.UnlockedUniversity {
 			if def, ok := data.RoomByID("university"); ok {
@@ -239,10 +235,10 @@ func (s *State) UnlockRoom(id string) error {
 	if !ok {
 		return fmt.Errorf("no such room: %s", id)
 	}
-	if s.Money < float64(def.UnlockCost) {
-		return fmt.Errorf("need $%d, have $%.0f", def.UnlockCost, s.Money)
+	if s.BTC < float64(def.UnlockCost) {
+		return fmt.Errorf("need ₿%d, have ₿%.0f", def.UnlockCost, s.BTC)
 	}
-	s.Money -= float64(def.UnlockCost)
+	s.BTC -= float64(def.UnlockCost)
 	s.unlockRoomInternal(def)
 	s.appendLog("info", fmt.Sprintf("Moved into %s.", def.Name))
 	return nil
@@ -311,15 +307,15 @@ func (s *State) BuyGPU(defID string) error {
 	if !ok {
 		return fmt.Errorf("no such GPU: %s", defID)
 	}
-	if s.Money < float64(def.Price) {
-		return fmt.Errorf("need $%d, have $%.0f", def.Price, s.Money)
+	if s.BTC < float64(def.Price) {
+		return fmt.Errorf("need ₿%d, have ₿%.0f", def.Price, s.BTC)
 	}
 	if !s.RoomHasFreeSlot(s.CurrentRoom) {
 		return fmt.Errorf("no free slots in this room")
 	}
-	s.Money -= float64(def.Price)
+	s.BTC -= float64(def.Price)
 	s.addGPU(defID, s.CurrentRoom, true)
-	s.appendLog("info", fmt.Sprintf("Ordered %s for $%d. Tracking inbound...", def.Name, def.Price))
+	s.appendLog("info", fmt.Sprintf("Ordered %s for ₿%d. Tracking inbound...", def.Name, def.Price))
 	return nil
 }
 
@@ -340,10 +336,10 @@ func (s *State) SellGPU(instanceID int) error {
 			value := float64(base) * s.ScrapValueMult()
 			// Also grant 1-3 research fragments.
 			frags := 1 + rand.Intn(3)
-			s.Money += value
+			s.BTC += value
 			s.ResearchFrags += frags
 			s.GPUs = append(s.GPUs[:i], s.GPUs[i+1:]...)
-			s.appendLog("info", fmt.Sprintf("Scrapped %s for $%.0f + %d research fragments.", name, value, frags))
+			s.appendLog("info", fmt.Sprintf("Scrapped %s for ₿%.0f + %d research fragments.", name, value, frags))
 			return nil
 		}
 	}
@@ -475,6 +471,16 @@ func LoadFrom(b []byte) (*State, error) {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return nil, err
 	}
+	// Pre-unification saves stored "money" (USD) alongside "btc" (mining
+	// intermediate, auto-sold at ~$300). Fold any legacy money into the
+	// single BTC balance. The tiny residual BTC from that era is already
+	// in s.BTC via the json tag and is numerically negligible.
+	var legacy struct {
+		Money float64 `json:"money"`
+	}
+	if err := json.Unmarshal(b, &legacy); err == nil && legacy.Money > 0 {
+		s.BTC += legacy.Money
+	}
 	s.ensureInit()
 	// Apply the player's persisted language choice to the i18n singleton.
 	if s.Lang != "" {
@@ -579,11 +585,11 @@ func (s *State) DifficultyBillMult() float64 { return s.Diff().BillMult }
 // DifficultyThreatMult is the event-fire-probability multiplier.
 func (s *State) DifficultyThreatMult() float64 { return s.Diff().ThreatMult }
 
-// SetDifficulty writes the chosen difficulty to state, applies starter cash,
-// and logs the choice. Called once from the splash picker.
+// SetDifficulty writes the chosen difficulty to state, applies the starter
+// balance, and logs the choice. Called once from the splash picker.
 func (s *State) SetDifficulty(id string) {
 	def := data.DifficultyByID(id)
 	s.Difficulty = def.ID
-	s.Money = def.StarterCash
+	s.BTC = def.StarterCash
 	s.appendLog("info", i18n.T("game.difficulty_set", def.LocalLabel()))
 }

--- a/core/game/state_test.go
+++ b/core/game/state_test.go
@@ -23,7 +23,7 @@ func TestNewStateInitialized(t *testing.T) {
 	if s.KittenName != "Test" {
 		t.Errorf("kitten name not applied")
 	}
-	if s.Money <= 0 {
+	if s.BTC <= 0 {
 		t.Error("new game should start with positive cash")
 	}
 	if len(s.GPUs) == 0 {
@@ -40,7 +40,7 @@ func TestNewStateInitialized(t *testing.T) {
 func TestStateSaveLoadRoundtrip(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Roundtrip")
-	s.Money = 12345
+	s.BTC = 12345
 	s.ResearchFrags = 7
 	s.UnlockedSkills["undervolt_i"] = true
 	if err := s.Save(); err != nil {
@@ -50,7 +50,7 @@ func TestStateSaveLoadRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if loaded.Money != 12345 || loaded.ResearchFrags != 7 {
+	if loaded.BTC != 12345 || loaded.ResearchFrags != 7 {
 		t.Errorf("numeric state did not roundtrip: %+v", loaded)
 	}
 	if !loaded.UnlockedSkills["undervolt_i"] {
@@ -85,7 +85,7 @@ func TestLoadFromBackfillsOldSaves(t *testing.T) {
 func TestBuyAndSellGPUFlow(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Flow")
-	s.Money = 10000
+	s.BTC = 10000
 	if err := s.BuyGPU("gtx1060"); err != nil {
 		t.Fatalf("buy: %v", err)
 	}
@@ -110,11 +110,11 @@ func TestBuyAndSellGPUFlow(t *testing.T) {
 	if starter == nil {
 		t.Fatal("expected a running starter GPU")
 	}
-	before := s.Money
+	before := s.BTC
 	if err := s.SellGPU(starter.InstanceID); err != nil {
 		t.Fatalf("sell: %v", err)
 	}
-	if s.Money <= before {
+	if s.BTC <= before {
 		t.Error("selling should add money")
 	}
 	if s.ResearchFrags <= 0 {
@@ -125,7 +125,7 @@ func TestBuyAndSellGPUFlow(t *testing.T) {
 func TestBuyGPUInsufficientFunds(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Broke")
-	s.Money = 1
+	s.BTC = 1
 	if err := s.BuyGPU("rtx4090"); err == nil {
 		t.Error("buying a $18k card with $1 should fail")
 	}
@@ -134,15 +134,15 @@ func TestBuyGPUInsufficientFunds(t *testing.T) {
 func TestUnlockRoomChargesMoney(t *testing.T) {
 	withTempHome(t)
 	s := NewState("Unlocker")
-	s.Money = 5000
-	before := s.Money
+	s.BTC = 5000
+	before := s.BTC
 	if err := s.UnlockRoom("warehouse"); err != nil {
 		t.Fatalf("unlock: %v", err)
 	}
 	if s.Rooms["warehouse"] == nil {
 		t.Error("warehouse should be unlocked")
 	}
-	if s.Money >= before {
+	if s.BTC >= before {
 		t.Error("unlocking should deduct money")
 	}
 }
@@ -185,7 +185,7 @@ func TestStateJSONTagsPresent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	for _, wanted := range []string{"kitten_name", "money", "current_room", "unlocked_skills", "mercs", "blueprints"} {
+	for _, wanted := range []string{"kitten_name", "btc", "current_room", "unlocked_skills", "mercs", "blueprints"} {
 		if !containsField(b, wanted) {
 			t.Errorf("marshaled state missing %q: %s", wanted, b)
 		}

--- a/core/game/stats.go
+++ b/core/game/stats.go
@@ -11,8 +11,8 @@ import (
 // heat trend, etc. without inventing numbers that would drift from what
 // the simulation actually does.
 
-// EarnRatePerSec returns the dollar earn rate for a single running GPU at
-// the current BTC price + active modifiers + active difficulty.
+// GPUEarnRatePerSec returns the BTC-per-second rate for a single running GPU
+// under the current active modifiers + difficulty + room heat.
 func (s *State) GPUEarnRatePerSec(g *GPU) float64 {
 	if g.Status != "running" {
 		return 0
@@ -27,8 +27,7 @@ func (s *State) GPUEarnRatePerSec(g *GPU) float64 {
 		effFactor = 0.5
 	}
 	earnMult := s.earnMultiplier(now)
-	btcPerSec := eff * earnMult * effFactor * s.DifficultyEarnMult()
-	return btcPerSec * s.BTCPriceAt(now)
+	return eff * earnMult * effFactor * s.DifficultyEarnMult() * MiningScale
 }
 
 // RoomEarnRatePerSec is the sum of per-GPU earn rates for every running GPU

--- a/core/game/tick.go
+++ b/core/game/tick.go
@@ -2,7 +2,6 @@ package game
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"time"
 
@@ -73,7 +72,6 @@ func (s *State) GPUStats(g *GPU) (eff, pow, heat, dur float64) {
 func (s *State) advanceMining(now int64, dt float64) {
 	miningPaused := s.IsMiningPaused(now)
 	earnMult := s.earnMultiplier(now)
-	price := s.BTCPriceAt(now)
 
 	for roomID, room := range s.Rooms {
 		roomDef, ok := data.RoomByID(roomID)
@@ -92,8 +90,9 @@ func (s *State) advanceMining(now int64, dt float64) {
 				efficiencyFactor = 0.5
 			}
 			if !miningPaused {
-				btcEarned := eff * dt * earnMult * efficiencyFactor * s.DifficultyEarnMult()
-				s.BTC += btcEarned
+				earned := eff * dt * earnMult * efficiencyFactor * s.DifficultyEarnMult() * MiningScale
+				s.BTC += earned
+				s.LifetimeEarned += earned
 			}
 
 			// Durability decay — GPUs wear out faster when the room is hot.
@@ -157,16 +156,6 @@ func (s *State) advanceMining(now int64, dt float64) {
 			room.Heat = room.MaxHeat
 		}
 	}
-
-	// Auto-cash-out BTC — small trickle so money moves too. Accumulate to
-	// LifetimeEarned for prestige tracking.
-	if s.BTC > 0 {
-		sell := s.BTC * (1 - math.Pow(0.95, dt))
-		cashIn := sell * price
-		s.Money += cashIn
-		s.LifetimeEarned += cashIn
-		s.BTC -= sell
-	}
 }
 
 // advanceBilling deducts electricity bill + rent every 60s.
@@ -196,13 +185,13 @@ func (s *State) advanceBilling(now int64) {
 		totalBill += volt * ElectricPerVoltMin * roomDef.ElectricCostMult * minutes * billMult
 		totalRent += float64(roomDef.RentPerHour) * (minutes / 60.0) * s.DifficultyBillMult()
 	}
-	s.Money -= totalBill
-	s.Money -= totalRent
+	s.BTC -= totalBill
+	s.BTC -= totalRent
 	if totalBill+totalRent > 0 {
-		s.appendLog("info", fmt.Sprintf("💸 Bills settled: $%.2f electricity, $%.2f rent.", totalBill, totalRent))
+		s.appendLog("info", fmt.Sprintf("💸 Bills settled: ₿%.2f electricity, ₿%.2f rent.", totalBill, totalRent))
 	}
-	if s.Money < 0 {
-		s.Money = 0
+	if s.BTC < 0 {
+		s.BTC = 0
 		s.Modifiers = append(s.Modifiers, Modifier{
 			Kind:      "pause_mining",
 			ExpiresAt: now + 60,
@@ -227,10 +216,10 @@ func (s *State) UpgradeGPU(instanceID int) error {
 			price = 3000 // MEOWCore default upgrade base
 		}
 		cost := price / 3
-		if s.Money < float64(cost) {
-			return fmt.Errorf("need $%d, have $%.0f", cost, s.Money)
+		if s.BTC < float64(cost) {
+			return fmt.Errorf("need ₿%d, have ₿%.0f", cost, s.BTC)
 		}
-		s.Money -= float64(cost)
+		s.BTC -= float64(cost)
 		failChance := 0.05 + 0.05*float64(g.UpgradeLevel)
 		if rand.Float64() < failChance {
 			g.Status = "broken"
@@ -259,15 +248,15 @@ func (s *State) EmergencyVent() error {
 	if room == nil {
 		return fmt.Errorf("no room")
 	}
-	if s.Money < EmergencyVentCost {
-		return fmt.Errorf("need $%d", EmergencyVentCost)
+	if s.BTC < EmergencyVentCost {
+		return fmt.Errorf("need ₿%d", EmergencyVentCost)
 	}
 	now := time.Now().Unix()
 	last := s.EventCooldown["vent:"+s.CurrentRoom]
 	if now-last < EmergencyVentCooldownSec {
 		return fmt.Errorf("cooldown: %ds left", EmergencyVentCooldownSec-(now-last))
 	}
-	s.Money -= EmergencyVentCost
+	s.BTC -= EmergencyVentCost
 	room.Heat = 20
 	room.LastHeatTickUnix = now // give the player a fresh interval after cooling
 	s.EventCooldown["vent:"+s.CurrentRoom] = now
@@ -275,7 +264,7 @@ func (s *State) EmergencyVent() error {
 		Kind:      "pause_mining",
 		ExpiresAt: now + 30,
 	})
-	s.appendLog("info", fmt.Sprintf("🧊 Emergency vent — heat reset, 30s power cycle, -$%d.", EmergencyVentCost))
+	s.appendLog("info", fmt.Sprintf("🧊 Emergency vent — heat reset, 30s power cycle, -₿%d.", EmergencyVentCost))
 	return nil
 }
 
@@ -305,11 +294,11 @@ func (s *State) TriggerPumpDump() error {
 	}
 	s.EventCooldown["pump_dump"] = now
 	s.Modifiers = append(s.Modifiers, Modifier{
-		Kind:      "btc_mult",
+		Kind:      "earn_mult",
 		Factor:    1.5,
 		ExpiresAt: now + 300,
 	})
-	s.appendLog("opportunity", "📈 Pump & Dump — BTC price ×1.5 for 5 minutes.")
+	s.appendLog("opportunity", "📈 Pump & Dump — mining output ×1.5 for 5 minutes.")
 	return nil
 }
 
@@ -340,10 +329,10 @@ func (s *State) UpgradeDefense(dim string) error {
 		return fmt.Errorf("%s already maxed", label)
 	}
 	cost := (*lvl + 1) * 250
-	if s.Money < float64(cost) {
-		return fmt.Errorf("need $%d, have $%.0f", cost, s.Money)
+	if s.BTC < float64(cost) {
+		return fmt.Errorf("need ₿%d, have ₿%.0f", cost, s.BTC)
 	}
-	s.Money -= float64(cost)
+	s.BTC -= float64(cost)
 	*lvl++
 	s.appendLog("info", fmt.Sprintf("🛡 %s upgraded to level %d.", label, *lvl))
 	return nil

--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -21,7 +21,6 @@ var enStrings = map[string]string{
 	"hdr.tp":    "TP %d",
 	"hdr.rep":   "Rep %+d",
 	"hdr.frags": "frags %d",
-	"hdr.price": "$%.0f/BTC",
 
 	"footer.keys": "[space] pause  [S] save  [L] lang  [?] help  [q] quit",
 
@@ -39,9 +38,9 @@ var enStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.line.volt":  "⚡ %.0fV draw  ·  bill −$%.3f/s  ·  next bill %ds",
+	"dash.line.volt":  "⚡ %.0fV draw  ·  bill −₿%.3f/s  ·  next bill %ds",
 	"dash.line.heat":  "🌡 %.0f°C / %.0f max  ·  %+.1f°C every %ds  ·  next in %ds",
-	"dash.line.cash":  "📈 earn +$%.3f/s  ·  net %+.3f/s",
+	"dash.line.cash":  "📈 earn +₿%.3f/s  ·  net %+.3f/s",
 	"dash.slots_of":   "slots %d/%d",
 	"dash.heat.warning":  "⚠ HOT — efficiency ½ · wear 3×",
 	"dash.heat.critical": "🔥 CRITICAL — wear 8× · GPU failure imminent",
@@ -89,7 +88,7 @@ var enStrings = map[string]string{
 	"rooms.help":       "↑/↓ room   [u] unlock   [enter] switch   [l/c/w/o/a] upgrade defense on current room   [esc]/[1] back",
 	"rooms.here":       "● here",
 	"rooms.unlocked":   "unlocked",
-	"rooms.to_unlock":  "$%d to unlock",
+	"rooms.to_unlock":  "₿%d to unlock",
 	"rooms.stats":      "  cooling %.1f · elec ×%.2f · threat base %.2f",
 	"rooms.defense":    "🛡  Defense — current room (%s)",
 	"rooms.dim.lock":    "Lock",
@@ -131,7 +130,7 @@ var enStrings = map[string]string{
 	"help.g.pump":     "[p]       Pump & Dump ability (dashboard, if unlocked)",
 	"help.g.lang":     "[L]       cycle language",
 	"help.g.quit":     "[q]       quit (auto-saves)",
-	"help.g.vent":     "[V]       emergency vent — reset room heat · -$100 · 30s pause · 2m cooldown",
+	"help.g.vent":     "[V]       emergency vent — reset room heat · -₿100 · 30s pause · 2m cooldown",
 	"help.defense":    "Room defense (from rooms view)",
 	"help.defense_row": "[l] lock · [c] CCTV · [w] wiring · [o] cooling · [a] armor",
 	"help.tip.idle":    "Tip: it's an incremental game — feel free to leave it running in tmux.",
@@ -139,12 +138,12 @@ var enStrings = map[string]string{
 
 	// Mercs.
 	"mercs.title":     "🐾 Mercenaries",
-	"mercs.help":      "[tab] switch tab   ↑/↓ select   [h] hire   [f] fire   [b] bribe (+15 loyalty, $200)   [esc]/[1] back",
+	"mercs.help":      "[tab] switch tab   ↑/↓ select   [h] hire   [f] fire   [b] bribe (+15 loyalty, ₿200)   [esc]/[1] back",
 	"mercs.yours":     "Your Mercs",
 	"mercs.empty":     "  (none — switch to Hire tab)",
 	"mercs.hire":      "Hire",
-	"mercs.owned_line": "room %s  wage $%d/wk  loyalty %d",
-	"mercs.hire_line":  "hire $%d",
+	"mercs.owned_line": "room %s  wage ₿%d/wk  loyalty %d",
+	"mercs.hire_line":  "hire ₿%d",
 	"mercs.defbonus":   "def +%.0f%%",
 	"mercs.loyalty":    "loyalty %d",
 
@@ -156,7 +155,7 @@ var enStrings = map[string]string{
 	"lab.active_none": "  (none)",
 	"lab.plan":        "Plan next research",
 	"lab.plan_tier":   "  Tier %d — %s",
-	"lab.plan_cost":   "  costs: $%d + %d frags  ·  duration: %dm",
+	"lab.plan_cost":   "  costs: ₿%d + %d frags  ·  duration: %dm",
 	"lab.plan_boosts": "  boosts: %s + %s",
 	"lab.plan_hint":   "  (press [r] to start)",
 	"lab.bp_title":    "Blueprints (%d) — [p] to print selected",
@@ -167,7 +166,7 @@ var enStrings = map[string]string{
 	"prestige.locked":  "Prestige is locked. Unlock 'Venture Capital' in the Mogul skill lane.",
 	"prestige.help":    "[↑/↓] select perk   [p] buy perk   [R] RETIRE (press twice to confirm)   [esc]/[1] back",
 	"prestige.status":  "Status",
-	"prestige.lifetime": "  lifetime earned: $%.0f / $%.0f",
+	"prestige.lifetime": "  lifetime earned: ₿%.0f / ₿%.0f",
 	"prestige.eligible_yes": "ELIGIBLE",
 	"prestige.eligible_no":  "not eligible",
 	"prestige.eligible_row": "  retirement status: %s",

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -21,7 +21,6 @@ var zhStrings = map[string]string{
 	"hdr.tp":    "TP %d",
 	"hdr.rep":   "声望 %+d",
 	"hdr.frags": "碎片 %d",
-	"hdr.price": "$%.0f/BTC",
 
 	"footer.keys": "[空格]暂停  [S]存档  [L]语言  [?]帮助  [q]退出",
 
@@ -39,9 +38,9 @@ var zhStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.line.volt":  "⚡ %.0fV 耗电  ·  账单 −$%.3f/秒  ·  下次结算 %d 秒",
+	"dash.line.volt":  "⚡ %.0fV 耗电  ·  账单 −₿%.3f/秒  ·  下次结算 %d 秒",
 	"dash.line.heat":  "🌡 %.0f°C / 最高 %.0f  ·  %+.1f°C 每 %d 秒  ·  下次 %d 秒",
-	"dash.line.cash":  "📈 收益 +$%.3f/秒  ·  扣费后净 %+.3f/秒",
+	"dash.line.cash":  "📈 收益 +₿%.3f/秒  ·  扣费后净 %+.3f/秒",
 	"dash.slots_of":   "槽位 %d/%d",
 	"dash.heat.warning":  "⚠ 温度过高 —— 效率减半 · 磨损 ×3",
 	"dash.heat.critical": "🔥 临界 —— 磨损 ×8 · 显卡即将烧毁",
@@ -89,7 +88,7 @@ var zhStrings = map[string]string{
 	"rooms.help":       "↑/↓ 选房间   [u] 解锁   [enter] 切换   [l/c/w/o/a] 升级当前房间的防御   [esc]/[1] 返回",
 	"rooms.here":       "● 此处",
 	"rooms.unlocked":   "已解锁",
-	"rooms.to_unlock":  "解锁 $%d",
+	"rooms.to_unlock":  "解锁 ₿%d",
 	"rooms.stats":      "  散热 %.1f · 电费 ×%.2f · 基础威胁 %.2f",
 	"rooms.defense":    "🛡  防御 —— 当前房间（%s）",
 	"rooms.dim.lock":    "门锁",
@@ -131,7 +130,7 @@ var zhStrings = map[string]string{
 	"help.g.pump":      "[p]      拉盘技能（主面板，需解锁）",
 	"help.g.lang":      "[L]      循环切换语言",
 	"help.g.quit":      "[q]      退出（自动存档）",
-	"help.g.vent":      "[V]      应急排热——重置房间温度 · -$100 · 30 秒停机 · 2 分钟冷却",
+	"help.g.vent":      "[V]      应急排热——重置房间温度 · -₿100 · 30 秒停机 · 2 分钟冷却",
 	"help.defense":     "房间防御（在房间视图里）",
 	"help.defense_row": "[l] 锁 · [c] 监控 · [w] 电路 · [o] 散热 · [a] 护甲",
 	"help.tip.idle":    "提示：这是增量器——放心开着 tmux 挂后台。",
@@ -139,12 +138,12 @@ var zhStrings = map[string]string{
 
 	// Mercs.
 	"mercs.title":      "🐾 佣兵",
-	"mercs.help":       "[tab] 切换标签   ↑/↓ 选择   [h] 雇佣   [f] 解雇   [b] 贿赂（忠诚 +15，$200）   [esc]/[1] 返回",
+	"mercs.help":       "[tab] 切换标签   ↑/↓ 选择   [h] 雇佣   [f] 解雇   [b] 贿赂（忠诚 +15，₿200）   [esc]/[1] 返回",
 	"mercs.yours":      "你的佣兵",
 	"mercs.empty":      "  （没有——切到雇佣标签）",
 	"mercs.hire":       "雇佣",
-	"mercs.owned_line": "房间 %s  周薪 $%d  忠诚 %d",
-	"mercs.hire_line":  "雇佣 $%d",
+	"mercs.owned_line": "房间 %s  周薪 ₿%d  忠诚 %d",
+	"mercs.hire_line":  "雇佣 ₿%d",
 	"mercs.defbonus":   "防御 +%.0f%%",
 	"mercs.loyalty":    "忠诚 %d",
 
@@ -156,7 +155,7 @@ var zhStrings = map[string]string{
 	"lab.active_none": "  （无）",
 	"lab.plan":        "下一次研究计划",
 	"lab.plan_tier":   "  档位 %d —— %s",
-	"lab.plan_cost":   "  消耗：$%d + %d 碎片  ·  用时：%d 分钟",
+	"lab.plan_cost":   "  消耗：₿%d + %d 碎片  ·  用时：%d 分钟",
 	"lab.plan_boosts": "  加成：%s + %s",
 	"lab.plan_hint":   "  （按 [r] 开始研究）",
 	"lab.bp_title":    "蓝图（%d 个）—— 按 [p] 打印选中的",
@@ -167,7 +166,7 @@ var zhStrings = map[string]string{
 	"prestige.locked":       "转生未解锁。先去大亨技能里解锁「Venture Capital」。",
 	"prestige.help":         "[↑/↓] 选特权   [p] 购买   [R] 退休（按两次确认）   [esc]/[1] 返回",
 	"prestige.status":       "状态",
-	"prestige.lifetime":     "  累计收入：$%.0f / $%.0f",
+	"prestige.lifetime":     "  累计收入：₿%.0f / ₿%.0f",
 	"prestige.eligible_yes": "可以转生",
 	"prestige.eligible_no":  "暂时还不行",
 	"prestige.eligible_row": "  退休资格：%s",

--- a/ui/app.go
+++ b/ui/app.go
@@ -353,7 +353,6 @@ func (a App) View() string {
 }
 
 func (a App) renderHeader() string {
-	price := a.state.CurrentBTCPrice()
 	paused := ""
 	if a.state.Paused {
 		paused = DimStyle.Render(i18n.T("app.pill_paused"))
@@ -365,9 +364,7 @@ func (a App) renderHeader() string {
 	title := TitleStyle.Render(fmt.Sprintf("%s — %s", i18n.T("app.title"), a.state.KittenName)) + diffBadge
 
 	extras := []string{
-		MoneyStyle.Render(fmt.Sprintf("$%.0f", a.state.Money)),
-		BTCStyle.Render(fmt.Sprintf("₿%.4f", a.state.BTC)),
-		DimStyle.Render(i18n.T("hdr.price", price)),
+		BTCStyle.Render(fmt.Sprintf("₿%.0f", a.state.BTC)),
 		DimStyle.Render(i18n.T("hdr.tp", a.state.TechPoint)),
 		DimStyle.Render(i18n.T("hdr.rep", a.state.Reputation)),
 		DimStyle.Render(i18n.T("hdr.frags", a.state.ResearchFrags)),
@@ -441,7 +438,7 @@ func (a App) renderDifficultyPicker() string {
 		} else {
 			title = DimStyle.Render(title)
 		}
-		meta := DimStyle.Render(fmt.Sprintf("(earn ×%.2f · bills ×%.2f · threats ×%.2f · $%.0f start)",
+		meta := DimStyle.Render(fmt.Sprintf("(earn ×%.2f · bills ×%.2f · threats ×%.2f · ₿%.0f start)",
 			d.EarnMult, d.BillMult, d.ThreatMult, d.StarterCash))
 		lines = append(lines, cursor+title+"   "+meta)
 		lines = append(lines, DimStyle.Render("    "+d.LocalDesc()))

--- a/ui/mercs.go
+++ b/ui/mercs.go
@@ -55,11 +55,11 @@ func (a App) renderMercsView() string {
 		if a.mercsTab == 1 && i == a.mercsCursor {
 			cursor = TitleStyle.Render("▶ ")
 		}
-		priceStyle := MoneyStyle
-		if a.state.Money < float64(d.HireCost) {
+		priceStyle := BTCStyle
+		if a.state.BTC < float64(d.HireCost) {
 			priceStyle = DimStyle
 		}
-		line := fmt.Sprintf("%s%-24s  %s  wage $%d/wk  %s",
+		line := fmt.Sprintf("%s%-24s  %s  wage ₿%d/wk  %s",
 			cursor, d.LocalName(),
 			priceStyle.Render(i18n.T("mercs.hire_line", d.HireCost)),
 			d.WeeklyWage, i18n.T("mercs.defbonus", d.DefenseBonus*100),

--- a/ui/rooms.go
+++ b/ui/rooms.go
@@ -43,9 +43,9 @@ func (a App) renderRoomsView() string {
 		case unlocked:
 			state = DimStyle.Render(i18n.T("rooms.unlocked"))
 		default:
-			state = MoneyStyle.Render(i18n.T("rooms.to_unlock", r.UnlockCost))
+			state = BTCStyle.Render(i18n.T("rooms.to_unlock", r.UnlockCost))
 		}
-		lines = append(lines, fmt.Sprintf("%s%-32s  %-10s  slots %-2d  rent $%d/h",
+		lines = append(lines, fmt.Sprintf("%s%-32s  %-10s  slots %-2d  rent ₿%d/h",
 			marker, r.LocalName(), state, r.Slots, r.RentPerHour,
 		))
 	}
@@ -75,7 +75,7 @@ func (a App) renderRoomsView() string {
 			if lvl >= 5 {
 				style = lipgloss.NewStyle().Foreground(OppGreen)
 			}
-			lines = append(lines, style.Render(fmt.Sprintf("  [%s] %-8s  lv %d/5   next $%d",
+			lines = append(lines, style.Render(fmt.Sprintf("  [%s] %-8s  lv %d/5   next ₿%d",
 				d.Key, i18n.T(d.I18n), lvl, next)))
 		}
 	}

--- a/ui/store.go
+++ b/ui/store.go
@@ -17,11 +17,11 @@ import (
 // but short enough that intentional repeated presses still feel snappy.
 const storeBuyCooldown = 400 * time.Millisecond
 
-func storeCatalog(money float64) []data.GPUDef {
+func storeCatalog(balance float64) []data.GPUDef {
 	all := data.GPUs()
 	out := []data.GPUDef{}
 	for _, g := range all {
-		if money >= float64(g.Price)*0.15 || g.Tier == "trash" || g.Tier == "common" {
+		if balance >= float64(g.Price)*0.15 || g.Tier == "trash" || g.Tier == "common" {
 			out = append(out, g)
 		}
 	}
@@ -29,7 +29,7 @@ func storeCatalog(money float64) []data.GPUDef {
 }
 
 func (a App) renderStore() string {
-	cat := storeCatalog(a.state.Money)
+	cat := storeCatalog(a.state.BTC)
 	lines := []string{TitleStyle.Render(i18n.T("store.title"))}
 	lines = append(lines, DimStyle.Render(i18n.T("store.help")))
 	lines = append(lines, "")
@@ -39,8 +39,8 @@ func (a App) renderStore() string {
 		if i == a.storeCursor {
 			marker = TitleStyle.Render("▶ ")
 		}
-		affordable := a.state.Money >= float64(g.Price)
-		priceStyle := MoneyStyle
+		affordable := a.state.BTC >= float64(g.Price)
+		priceStyle := BTCStyle
 		if !affordable {
 			priceStyle = DimStyle
 		}
@@ -51,7 +51,7 @@ func (a App) renderStore() string {
 		lines = append(lines, fmt.Sprintf("%s%-32s  %s  %s",
 			marker,
 			name,
-			priceStyle.Render(fmt.Sprintf("$%-6d", g.Price)),
+			priceStyle.Render(fmt.Sprintf("₿%-6d", g.Price)),
 			DimStyle.Render(fmt.Sprintf("%s   %.0fV   %dh",
 				i18n.T("label.eff", g.Efficiency), g.PowerDraw, g.DurabilityHours)),
 		))
@@ -66,7 +66,7 @@ func (a App) renderStore() string {
 }
 
 func (a App) handleStoreKey(key string) (tea.Model, tea.Cmd) {
-	cat := storeCatalog(a.state.Money)
+	cat := storeCatalog(a.state.BTC)
 	switch key {
 	case "up", "k":
 		if a.storeCursor > 0 {


### PR DESCRIPTION
## Summary

- Drop the BTC price oscillator + auto-cashout loop; `State.Money` is gone — everything is a single `State.BTC` balance now.
- Add `MiningScale = 300.0` so existing store prices, rent, defense costs etc. still feel right (~old Money/s converted at $300).
- Events keep their economic flavor: `btc_multiplier` effects become `earn_multiplier`, and a new `voltage_dip` event lowers earn rate 40% for 5min (thematic "power instability").
- Repurpose `hedged_wallet` skill: was price-volatility damp (btc_damp), now event earn-swing damp (earn_damp). Prestige chain (`venture_cap`) unchanged.
- UI: header drops the price widget; all prices show `₿` directly. Legacy saves with `"money"` field auto-migrate into BTC on load.

## Motivation

Dual-currency (Money + BTC with an oscillating conversion rate) added conversion friction without gameplay depth — the price curve wasn't a core mechanic. Keep it simple: single currency, events still move the earn rate up/down for market flavor.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (economy_test + state_test + skills_test + research_test migrated)
- [ ] New run starts with positive BTC, starter GPU produces visible ₿/s
- [ ] Legacy save (with `"money": N`) loads without error and preserves balance
- [ ] `voltage_dip` event fires and dashes earn rate for its duration