### PR TITLE
feat: startup update-check with skip-this-version prompt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,19 @@ jobs:
       - name: Cross-compile 8 binaries
         run: |
           mkdir -p bin
+          # Inject the tag name as main.Version so the running binary
+          # knows its own release — powers the startup update check.
+          # meowmine-ssh doesn't run the check (multiplayer server
+          # doesn't own the player's browser), so the ldflag is harmless
+          # there; it just leaves main.Version unset in that package.
+          VERSION="${GITHUB_REF_NAME}"
           for target in "windows amd64 .exe" "linux amd64 " "darwin amd64 " "darwin arm64 "; do
             set -- $target
             os=$1; arch=$2; ext=$3
             for cmd in meowmine meowmine-ssh; do
               echo "building $cmd-$os-$arch$ext"
-              GOOS=$os GOARCH=$arch go build -ldflags "-s -w" \
+              GOOS=$os GOARCH=$arch go build \
+                -ldflags "-s -w -X main.Version=${VERSION}" \
                 -o "bin/$cmd-$os-$arch$ext" "./cmd/$cmd"
             done
           done

--- a/cmd/meowmine/main.go
+++ b/cmd/meowmine/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -9,8 +10,14 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/update"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/ui"
 )
+
+// Version is stamped at build time via ldflags on release. Dev builds
+// (go run / go build with no ldflags) see "dev" and skip the update
+// check entirely — we don't want to nag developers on every iteration.
+var Version = "dev"
 
 func main() {
 	newGame := flag.Bool("new", false, "start a new game, discarding any save")
@@ -51,10 +58,58 @@ func main() {
 	}
 
 	p := tea.NewProgram(ui.NewApp(state), tea.WithAltScreen())
+
+	// Fire the update check in a goroutine BEFORE the tea Program runs.
+	// Once it resolves we deliver the result via p.Send so the App
+	// transitions into the splashUpdate phase. Anything that fails
+	// (offline, HTTP error, same version, dismissed tag) is silent.
+	go runStartupUpdateCheck(p)
+
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "ui error: %v\n", err)
 		os.Exit(1)
 	}
 	// Final save on clean exit.
 	_ = state.Save()
+}
+
+// runStartupUpdateCheck performs the GitHub releases lookup and, if a
+// newer stable release is available and hasn't been "skip"-dismissed by
+// the player, dispatches an ui.UpdateAvailableMsg into the tea program.
+//
+// Every failure mode here is swallowed — silence is the feature. A
+// player offline at startup must see zero difference from a player who
+// happens to be on the latest version.
+func runStartupUpdateCheck(p *tea.Program) {
+	// Dev builds (Version == "dev", empty, or anything that doesn't
+	// parse as semver) skip entirely — the update check is only for
+	// published binaries that know their own tag.
+	if Version == "" || Version == "dev" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	info, err := update.Check(ctx)
+	if err != nil || info == nil {
+		return
+	}
+	if !update.IsNewer(Version, info.TagName) {
+		return
+	}
+	dismissPath := update.DefaultDismissFile()
+	dismissed, _ := update.LoadDismissed(dismissPath)
+	if update.IsDismissed(dismissed, info.TagName) {
+		return
+	}
+
+	body := update.TruncateLines(update.StripMarkdown(info.Body), 12)
+	p.Send(ui.UpdateAvailableMsg{
+		CurrentVersion:  Version,
+		LatestVersion:   info.TagName,
+		HTMLURL:         info.HTMLURL,
+		Body:            body,
+		DismissFilePath: dismissPath,
+	})
 }

--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -197,4 +197,17 @@ var enStrings = map[string]string{
 
 	// Minimum terminal size warning.
 	"warn.terminal_too_small": "Please widen your terminal to at least 80x22.",
+
+	// Update-available splash — shown on startup when GitHub reports a
+	// newer release than the running binary. See core/update and
+	// ui/update_splash.go.
+	"update.title":     "🆕 Update available",
+	"update.from_to":   "Current: %s   →   Latest: %s",
+	"update.changelog": "What's new:",
+	"update.no_notes":  "(no changelog)",
+	"update.opt.yes":   "Open release page",
+	"update.opt.no":    "Remind me next time",
+	"update.opt.skip":  "Skip this version",
+	"update.help":      "[↑/↓] select  [enter] confirm  [y] open  [n] later  [s] skip  [o] release notes  [ctrl+c] quit",
+	"update.opening":   "Opening %s ...",
 }

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -196,4 +196,15 @@ var zhStrings = map[string]string{
 	"hdr.achievements":    "🏆 %d/%d",
 
 	"warn.terminal_too_small": "终端太小了，请至少调到 80x22。",
+
+	// 启动时的新版本提示弹窗。参数顺序必须与 en.go 保持一致。
+	"update.title":     "🆕 发现新版本",
+	"update.from_to":   "当前：%s   →   最新：%s",
+	"update.changelog": "更新内容：",
+	"update.no_notes":  "（暂无更新说明）",
+	"update.opt.yes":   "打开发布页面",
+	"update.opt.no":    "下次再提醒我",
+	"update.opt.skip":  "跳过此版本",
+	"update.help":      "[↑/↓] 选择  [enter] 确认  [y] 打开  [n] 稍后  [s] 跳过  [o] 发布说明  [ctrl+c] 退出",
+	"update.opening":   "正在打开 %s ...",
 }

--- a/core/update/check.go
+++ b/core/update/check.go
@@ -1,0 +1,297 @@
+// Package update implements a pragmatic, best-effort check against the
+// project's GitHub releases feed to notify players when a newer build is
+// available. It is explicitly NOT a self-updater: opening the release page
+// in the player's browser is the honest UX for a cross-platform Go binary.
+//
+// Design notes:
+//
+//   - The check runs in a short-timeout goroutine at startup so offline /
+//     slow networks never delay the TUI. Failures are swallowed silently.
+//   - Semver parsing is deliberately minimal — split on ".", integer
+//     compare, ignore suffixes. If a tag fails to parse we treat it as
+//     "no update" (fail closed) so malformed tags never spam the prompt.
+//   - The release body is GitHub's auto-generated notes (markdown). We do
+//     NOT pull in a markdown library; we just strip the noisiest syntax
+//     and keep it short enough for a splash panel.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ReleasesAPIURL is the canonical GitHub API endpoint for the "latest"
+// release of the project.
+const ReleasesAPIURL = "https://api.github.com/repos/RandomNameORG/kitten-crypto-mining-ventures/releases/latest"
+
+// ReleasesPageURL is the human-facing releases page, used when we ask the
+// OS to open the browser.
+const ReleasesPageURL = "https://github.com/RandomNameORG/kitten-crypto-mining-ventures/releases/latest"
+
+// Info summarises what we learned about the latest release. It is returned
+// from Check and consumed by the UI layer; all fields are safe to render
+// verbatim after being run through StripMarkdown for body text.
+type Info struct {
+	// TagName is the raw tag (e.g. "v1.2.3").
+	TagName string
+	// HTMLURL is the GitHub page for this release.
+	HTMLURL string
+	// Body is the raw release notes (markdown).
+	Body string
+}
+
+// apiResponse is the subset of GitHub's release JSON we care about.
+type apiResponse struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+	Body    string `json:"body"`
+	// Draft/Prerelease we use to skip those — we only prompt for real
+	// stable releases so players aren't bounced onto unfinished builds.
+	Draft      bool `json:"draft"`
+	Prerelease bool `json:"prerelease"`
+}
+
+// Check queries the GitHub releases API and returns the latest release
+// metadata. The supplied context controls cancellation; callers should
+// supply a short timeout (3s is the house default).
+//
+// A non-nil error means "we couldn't determine"; callers should treat this
+// as "no update" and proceed silently.
+func Check(ctx context.Context) (*Info, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ReleasesAPIURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	// GitHub recommends an explicit Accept header for the REST API.
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "meowmine-update-check")
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("update check: unexpected status %d", resp.StatusCode)
+	}
+
+	var api apiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&api); err != nil {
+		return nil, err
+	}
+	if api.Draft || api.Prerelease {
+		return nil, errors.New("update check: latest is a draft or prerelease")
+	}
+	if strings.TrimSpace(api.TagName) == "" {
+		return nil, errors.New("update check: empty tag name")
+	}
+	return &Info{
+		TagName: api.TagName,
+		HTMLURL: api.HTMLURL,
+		Body:    api.Body,
+	}, nil
+}
+
+// IsNewer reports whether `latest` is strictly greater than `current`
+// using a minimal semver comparison (leading `v` stripped, dot-separated
+// integers, shorter version treated as having trailing zeroes).
+//
+// If either version fails to parse we return false — callers should
+// prefer silence over a spammy prompt when data is ambiguous.
+func IsNewer(current, latest string) bool {
+	cur, ok1 := parseSemver(current)
+	lat, ok2 := parseSemver(latest)
+	if !ok1 || !ok2 {
+		return false
+	}
+	// Pad to equal length so e.g. "1.0" vs "1.0.0" compares as equal.
+	for len(cur) < len(lat) {
+		cur = append(cur, 0)
+	}
+	for len(lat) < len(cur) {
+		lat = append(lat, 0)
+	}
+	for i := range cur {
+		if lat[i] > cur[i] {
+			return true
+		}
+		if lat[i] < cur[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// parseSemver converts "v1.2.3" / "1.2.3" / "1.2" into a slice of ints.
+// Trailing suffixes like "-beta.1" or "+build.7" are dropped after the
+// first non-numeric segment, keeping the numeric prefix. Returns ok=false
+// if the string has zero numeric segments.
+func parseSemver(s string) ([]int, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	s = strings.TrimPrefix(s, "V")
+	if s == "" {
+		return nil, false
+	}
+	// Cut pre-release / build metadata; everything before the first
+	// non-digit-non-dot byte is the numeric core.
+	cut := len(s)
+	for i, r := range s {
+		if r == '.' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		cut = i
+		break
+	}
+	core := s[:cut]
+	if core == "" {
+		return nil, false
+	}
+	parts := strings.Split(core, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			return nil, false
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// StripMarkdown converts a GitHub release body (lightweight markdown) into
+// plain-ish text suitable for a TUI splash. It is intentionally simple —
+// the goal is legibility, not fidelity. Headings become plain lines,
+// bullets keep their shape, inline emphasis (`**bold**`, `*em*`, `` ` ``)
+// is dropped, link syntax `[text](url)` becomes `text (url)`.
+func StripMarkdown(md string) string {
+	lines := strings.Split(strings.ReplaceAll(md, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		// Trim ATX headings: "## Foo" -> "Foo".
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "#") {
+			line = strings.TrimLeft(trimmed, "#")
+			line = strings.TrimSpace(line)
+		}
+		// Normalise bullets: "* foo", "+ foo" -> "- foo".
+		t := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(t, "* ") || strings.HasPrefix(t, "+ ") {
+			indent := line[:len(line)-len(t)]
+			line = indent + "- " + strings.TrimPrefix(strings.TrimPrefix(t, "* "), "+ ")
+		}
+		// Drop bold/italic/code markers and HTML comments.
+		line = stripInline(line)
+		out = append(out, line)
+	}
+	// Collapse runs of blank lines — GitHub notes often have lots.
+	collapsed := make([]string, 0, len(out))
+	blank := false
+	for _, l := range out {
+		if strings.TrimSpace(l) == "" {
+			if blank {
+				continue
+			}
+			blank = true
+		} else {
+			blank = false
+		}
+		collapsed = append(collapsed, l)
+	}
+	return strings.TrimSpace(strings.Join(collapsed, "\n"))
+}
+
+// stripInline removes the noisiest inline markdown tokens.
+func stripInline(s string) string {
+	// [text](url) -> text (url)
+	s = linkRegex(s)
+	// Drop **bold** and __bold__ markers but keep the text.
+	s = strings.ReplaceAll(s, "**", "")
+	s = strings.ReplaceAll(s, "__", "")
+	// Drop inline code backticks.
+	s = strings.ReplaceAll(s, "`", "")
+	// Drop single-char emphasis markers ( *em* / _em_ ) — naive, but
+	// markdown that reaches us here is GitHub-generated so it's tidy.
+	s = strings.ReplaceAll(s, "*", "")
+	// Drop leading "> " blockquotes.
+	trim := strings.TrimLeft(s, " \t")
+	if strings.HasPrefix(trim, "> ") {
+		indent := s[:len(s)-len(trim)]
+		s = indent + strings.TrimPrefix(trim, "> ")
+	}
+	return s
+}
+
+// linkRegex converts "[text](url)" -> "text (url)" without pulling in the
+// regexp package for such a tiny rewrite.
+func linkRegex(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] != '[' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		// Find matching "](".
+		close1 := strings.Index(s[i:], "](")
+		if close1 < 0 {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		close1 += i
+		close2 := strings.Index(s[close1:], ")")
+		if close2 < 0 {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		close2 += close1
+		text := s[i+1 : close1]
+		url := s[close1+2 : close2]
+		if text != "" && url != "" {
+			b.WriteString(text)
+			b.WriteString(" (")
+			b.WriteString(url)
+			b.WriteString(")")
+		} else {
+			b.WriteString(s[i : close2+1])
+		}
+		i = close2 + 1
+	}
+	return b.String()
+}
+
+// TruncateLines clips `text` to at most `max` lines, adding an ellipsis
+// marker line when truncation occurs. Used to keep the changelog panel
+// from exploding on verbose releases.
+func TruncateLines(text string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	if len(lines) <= max {
+		return text
+	}
+	kept := lines[:max]
+	return strings.Join(kept, "\n") + "\n…"
+}

--- a/core/update/check_test.go
+++ b/core/update/check_test.go
@@ -1,0 +1,111 @@
+package update
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsNewer_BasicOrdering anchors the critical happy path — a fresh
+// patch release must be detected. If this breaks, players on old builds
+// would miss prompts entirely, which is the whole feature's reason for
+// existing.
+func TestIsNewer_BasicOrdering(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+		name            string
+	}{
+		{"v1.0.0", "v1.0.1", true, "patch bump"},
+		{"v1.2.3", "v1.10.0", true, "double-digit minor is not lexicographic"},
+		{"v1.0", "v1.0.0", false, "padded equal"},
+		{"v1.0.0", "v1.0.0", false, "identical"},
+		{"v1.3.0", "v1.2.9", false, "older not newer"},
+		{"1.0.0", "1.0.1", true, "no v prefix"},
+		{"v0.1.0", "v1.0.0", true, "major bump"},
+		{"v2.0.0", "v1.9.9", false, "major regression not newer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsNewer(tc.current, tc.latest)
+			if got != tc.want {
+				t.Fatalf("IsNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsNewer_FailClosed — malformed inputs MUST return false so a broken
+// tag on GitHub never triggers a noisy prompt loop.
+func TestIsNewer_FailClosed(t *testing.T) {
+	cases := []struct {
+		current, latest string
+	}{
+		{"", "v1.0.0"},
+		{"v1.0.0", ""},
+		{"notaversion", "v1.0.0"},
+		{"v1.0.0", "garbage"},
+		{"v-", "v1.0.0"},
+	}
+	for _, tc := range cases {
+		if IsNewer(tc.current, tc.latest) {
+			t.Fatalf("IsNewer(%q,%q) unexpectedly true", tc.current, tc.latest)
+		}
+	}
+}
+
+// TestIsNewer_PrereleaseSuffix — suffixes are dropped; the numeric prefix
+// drives comparison. This keeps "v1.2.3-beta" from appearing newer than
+// "v1.2.3" (the main channel), which would look wrong to the player.
+func TestIsNewer_PrereleaseSuffix(t *testing.T) {
+	if IsNewer("v1.2.3", "v1.2.3-beta") {
+		t.Fatalf("prerelease suffix should not register as newer than stable")
+	}
+	if !IsNewer("v1.2.3-beta", "v1.2.4") {
+		t.Fatalf("v1.2.4 should be newer than v1.2.3-beta")
+	}
+}
+
+// TestStripMarkdown_Basic ensures the most common GitHub release syntax
+// is normalised into readable text without leaning on a markdown library.
+// Regressions here show up as garbled panel content, which would erode
+// trust in the prompt.
+func TestStripMarkdown_Basic(t *testing.T) {
+	in := "## What's Changed\n" +
+		"* **Big thing** by @you in [#42](https://example.com/42)\n" +
+		"* Another `inline` fix\n" +
+		"\n\n" +
+		"**Full Changelog**: https://example.com/compare\n"
+	out := StripMarkdown(in)
+	if strings.Contains(out, "##") {
+		t.Errorf("heading marker not stripped: %q", out)
+	}
+	if strings.Contains(out, "**") {
+		t.Errorf("bold markers not stripped: %q", out)
+	}
+	if strings.Contains(out, "`") {
+		t.Errorf("backticks not stripped: %q", out)
+	}
+	if !strings.Contains(out, "- ") {
+		t.Errorf("bullet marker missing: %q", out)
+	}
+	if !strings.Contains(out, "(https://example.com/42)") {
+		t.Errorf("link URL not preserved alongside text: %q", out)
+	}
+	// Runs of blanks should collapse.
+	if strings.Contains(out, "\n\n\n") {
+		t.Errorf("triple blank lines not collapsed: %q", out)
+	}
+}
+
+func TestTruncateLines(t *testing.T) {
+	in := "a\nb\nc\nd\ne"
+	if got := TruncateLines(in, 3); got != "a\nb\nc\n…" {
+		t.Fatalf("got %q", got)
+	}
+	if got := TruncateLines(in, 10); got != in {
+		t.Fatalf("no-op truncate changed input: %q", got)
+	}
+	if got := TruncateLines(in, 0); got != "" {
+		t.Fatalf("zero truncate should be empty: %q", got)
+	}
+}

--- a/core/update/dismiss.go
+++ b/core/update/dismiss.go
@@ -1,0 +1,108 @@
+// dismiss.go manages the tiny cross-run config file that remembers which
+// release tags the player has "skip"-dismissed. Kept deliberately outside
+// the game State because:
+//
+//   - It's meta-config (user preference), not save data.
+//   - It persists even when the player starts a fresh save.
+//   - It needs to be cheap to read/write at startup before the full
+//     state is loaded.
+//
+// Format is the simplest thing that works: one tag per line in
+// `~/.meowmine/dismissed_versions.txt`. Order / dedup is enforced on
+// write. Missing file is fine — means "none dismissed yet".
+package update
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultDismissFile returns the conventional location for the dismissed
+// versions file. Mirrors game.SavePath() by living under ~/.meowmine/.
+func DefaultDismissFile() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".meowmine", "dismissed_versions.txt")
+	}
+	return filepath.Join(home, ".meowmine", "dismissed_versions.txt")
+}
+
+// LoadDismissed reads the dismissed-versions file at `path`. A missing
+// file yields an empty slice and nil error — "nothing dismissed yet" is
+// the normal first-run state.
+func LoadDismissed(path string) ([]string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SaveDismissed writes the deduplicated list to `path`. Callers should
+// typically pass the result of AppendDismissed so ordering is preserved.
+func SaveDismissed(path string, tags []string) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	seen := map[string]bool{}
+	var buf bytes.Buffer
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		buf.WriteString(t)
+		buf.WriteByte('\n')
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+// IsDismissed reports whether `tag` is present in `list` (exact match,
+// case-insensitive — tags are conventionally lowercase but we don't want
+// a stray "V1.2.3" to defeat the check).
+func IsDismissed(list []string, tag string) bool {
+	needle := strings.ToLower(strings.TrimSpace(tag))
+	if needle == "" {
+		return false
+	}
+	for _, t := range list {
+		if strings.ToLower(strings.TrimSpace(t)) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// AppendDismissed returns a new list containing `tag` exactly once.
+// If `tag` is already present the original list is returned unchanged.
+func AppendDismissed(list []string, tag string) []string {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return list
+	}
+	if IsDismissed(list, tag) {
+		return list
+	}
+	return append(append([]string(nil), list...), tag)
+}

--- a/core/update/dismiss_test.go
+++ b/core/update/dismiss_test.go
@@ -1,0 +1,58 @@
+package update
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestDismissRoundtrip — the user-visible promise is "Skip this version"
+// silences future prompts for that exact tag. This test anchors that
+// round-trip: write, read, confirm the tag is remembered.
+func TestDismissRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dismissed_versions.txt")
+
+	list, err := LoadDismissed(path)
+	if err != nil {
+		t.Fatalf("load missing file: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %v", list)
+	}
+
+	list = AppendDismissed(list, "v1.2.3")
+	list = AppendDismissed(list, "v1.2.3") // dedup check
+	list = AppendDismissed(list, "v1.3.0")
+	if len(list) != 2 {
+		t.Fatalf("expected dedup to 2 entries, got %v", list)
+	}
+	if err := SaveDismissed(path, list); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	back, err := LoadDismissed(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(back) != 2 {
+		t.Fatalf("expected 2 persisted, got %v", back)
+	}
+	if !IsDismissed(back, "v1.2.3") {
+		t.Fatalf("v1.2.3 should be dismissed: %v", back)
+	}
+	if !IsDismissed(back, "V1.2.3") {
+		t.Fatalf("case-insensitive match failed: %v", back)
+	}
+	if IsDismissed(back, "v9.9.9") {
+		t.Fatalf("v9.9.9 should not be dismissed")
+	}
+}
+
+// TestAppendDismissed_EmptyTag — we never want stray blank lines in the
+// persisted file; they'd accumulate on every write.
+func TestAppendDismissed_EmptyTag(t *testing.T) {
+	got := AppendDismissed(nil, "   ")
+	if len(got) != 0 {
+		t.Fatalf("blank tag should not be appended: %v", got)
+	}
+}

--- a/ui/app.go
+++ b/ui/app.go
@@ -39,6 +39,11 @@ const (
 	splashNone splashPhase = iota
 	splashName
 	splashDifficulty
+	// splashUpdate is gated by a successful UpdateAvailableMsg — without
+	// one we never enter this phase. It runs BEFORE name / difficulty so
+	// returning players see the prompt on every launch until they pick
+	// "yes" or "skip".
+	splashUpdate
 )
 
 type App struct {
@@ -69,6 +74,14 @@ type App struct {
 	splashPhase    splashPhase
 	nameEntryBuf   string
 	diffPickerCur  int
+
+	// Update-available splash state. updateActive is set when a
+	// ui.UpdateAvailableMsg arrives; see ui/update_splash.go. The
+	// main binary is responsible for running the check and injecting
+	// the message — the App itself is transport-agnostic.
+	updateActive bool
+	updateInfo   UpdateAvailableMsg
+	updateCursor int
 
 	// Retire confirmation — double-press [R] within a short window.
 	retireArmedUntil time.Time
@@ -125,8 +138,21 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, tickCmd()
 
+	case UpdateAvailableMsg:
+		// Inject the update prompt as the first splash phase. If the
+		// player is mid-name-entry or mid-difficulty when this lands
+		// (unlikely given the 3s HTTP timeout, but possible) we still
+		// take over — the prompt is about meta-lifecycle, not the run.
+		a.updateInfo = m
+		a.updateActive = true
+		a.splashPhase = splashUpdate
+		a.updateCursor = updateOptYes
+		return a, nil
+
 	case tea.KeyMsg:
 		switch a.splashPhase {
+		case splashUpdate:
+			return a.handleUpdateSplash(m)
 		case splashName:
 			return a.handleNameEntry(m)
 		case splashDifficulty:
@@ -309,6 +335,8 @@ func (a App) View() string {
 		return i18n.T("warn.terminal_too_small")
 	}
 	switch a.splashPhase {
+	case splashUpdate:
+		return a.renderUpdateSplash()
 	case splashName:
 		return a.renderNameEntry()
 	case splashDifficulty:

--- a/ui/update_splash.go
+++ b/ui/update_splash.go
@@ -1,0 +1,199 @@
+// update_splash.go renders the "new version available" pre-game splash
+// and handles its key bindings. It's layered BEFORE the name / difficulty
+// splash phases so returning players see it first on launch.
+//
+// The panel is populated from a ui.UpdateAvailableMsg delivered by the
+// main binary's startup goroutine (see cmd/meowmine/main.go). If no
+// message arrives before the player reaches the splash loop, this phase
+// is skipped entirely — offline / slow-network users see zero friction.
+package ui
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/update"
+)
+
+// UpdateAvailableMsg is dispatched by the startup update check once the
+// HTTP response has been successfully parsed and the version comparison
+// confirms the release is newer than the running binary.
+type UpdateAvailableMsg struct {
+	CurrentVersion string
+	LatestVersion  string
+	HTMLURL        string
+	// Body is pre-stripped / truncated plaintext ready to render.
+	Body string
+	// DismissFilePath is where to write "skip this version" state.
+	DismissFilePath string
+}
+
+// updateSplashOptions maps cursor index → semantic key. Kept in one place
+// so arrow-key + enter-commit stays consistent with the hotkey handlers.
+const (
+	updateOptYes  = 0
+	updateOptNo   = 1
+	updateOptSkip = 2
+)
+
+var updateOptCount = 3
+
+// handleUpdateSplash dispatches key events for the update-available
+// splash phase. Mirrors the arrow-key style of the difficulty splash so
+// players don't have to relearn navigation.
+func (a App) handleUpdateSplash(k tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := k.String()
+	switch key {
+	case "ctrl+c":
+		return a, tea.Quit
+	case "up", "k":
+		if a.updateCursor > 0 {
+			a.updateCursor--
+		}
+		return a, nil
+	case "down", "j":
+		if a.updateCursor < updateOptCount-1 {
+			a.updateCursor++
+		}
+		return a, nil
+	case "enter":
+		return a.applyUpdateChoice(a.updateCursor)
+	case "y", "Y":
+		return a.applyUpdateChoice(updateOptYes)
+	case "o", "O":
+		// Explicit "open release notes" shortcut — same action as Yes
+		// but advertised separately because players often just want
+		// to skim the changelog without committing to an upgrade.
+		return a.applyUpdateChoice(updateOptYes)
+	case "n", "N", "esc":
+		return a.applyUpdateChoice(updateOptNo)
+	case "s", "S":
+		return a.applyUpdateChoice(updateOptSkip)
+	}
+	return a, nil
+}
+
+// applyUpdateChoice executes the player's selection and advances past
+// the update splash. All three paths leave the app in the same post-
+// splash state; the difference is only what gets persisted / launched.
+func (a App) applyUpdateChoice(choice int) (tea.Model, tea.Cmd) {
+	info := a.updateInfo
+	switch choice {
+	case updateOptYes:
+		// Best-effort: fire and forget. If opening fails we still
+		// advance — the URL was visible in the panel, the player can
+		// copy it. We set a transient status so the next splash /
+		// dashboard shows a breadcrumb.
+		_ = openBrowser(info.HTMLURL)
+		a = a.withStatus(i18n.T("update.opening", info.HTMLURL))
+	case updateOptSkip:
+		// Persist the tag; ignore errors — a write failure means the
+		// prompt will return next launch, which is annoying but not
+		// data loss. Silent log entry helps debugging.
+		list, _ := update.LoadDismissed(info.DismissFilePath)
+		list = update.AppendDismissed(list, info.LatestVersion)
+		if err := update.SaveDismissed(info.DismissFilePath, list); err != nil {
+			a.state.AppendLog("info", fmt.Sprintf("update: failed to persist skip: %v", err))
+		}
+	case updateOptNo:
+		// No-op — session-only dismiss.
+	}
+	a.updateActive = false
+	// Advance to whichever splash phase the name / difficulty flow
+	// would normally have started on.
+	switch {
+	case a.state.KittenName == "":
+		a.splashPhase = splashName
+	case a.state.Difficulty == "":
+		a.splashPhase = splashDifficulty
+		a.diffPickerCur = 1
+	default:
+		a.splashPhase = splashNone
+	}
+	return a, nil
+}
+
+// renderUpdateSplash draws the panel. Visual style matches the
+// difficulty splash so it feels native — same TitleStyle, PanelStyle,
+// bullet indicator.
+func (a App) renderUpdateSplash() string {
+	info := a.updateInfo
+	title := TitleStyle.Render(fmt.Sprintf("%s — %s → %s",
+		i18n.T("update.title"),
+		info.CurrentVersion,
+		info.LatestVersion,
+	))
+
+	fromTo := DimStyle.Render(i18n.T("update.from_to", info.CurrentVersion, info.LatestVersion))
+
+	body := strings.TrimSpace(info.Body)
+	if body == "" {
+		body = i18n.T("update.no_notes")
+	}
+	changelog := strings.Join([]string{
+		DimStyle.Render(i18n.T("update.changelog")),
+		body,
+	}, "\n")
+
+	opts := []string{
+		i18n.T("update.opt.yes"),
+		i18n.T("update.opt.no"),
+		i18n.T("update.opt.skip"),
+	}
+	rendered := make([]string, 0, len(opts))
+	for i, label := range opts {
+		cursor := "  "
+		line := label
+		if i == a.updateCursor {
+			cursor = TitleStyle.Render("▶ ")
+			line = TitleStyle.Render(line)
+		} else {
+			line = DimStyle.Render(line)
+		}
+		rendered = append(rendered, cursor+line)
+	}
+	optBlock := strings.Join(rendered, "\n")
+
+	urlLine := DimStyle.Render(info.HTMLURL)
+	help := DimStyle.Render(i18n.T("update.help"))
+
+	panel := PanelStyle.Render(strings.Join([]string{
+		title,
+		fromTo,
+		"",
+		changelog,
+		"",
+		optBlock,
+		"",
+		urlLine,
+	}, "\n"))
+
+	return lipgloss.NewStyle().Padding(2, 4).Render(panel + "\n" + help)
+}
+
+// openBrowser asks the host OS to open `url`. This is a best-effort
+// cross-platform launcher — we explicitly avoid pulling in a dependency
+// (github.com/pkg/browser) because std-lib is enough for the three
+// platforms we ship binaries for.
+func openBrowser(url string) error {
+	if strings.TrimSpace(url) == "" {
+		return fmt.Errorf("update: empty URL")
+	}
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		// linux, *bsd, etc. — xdg-open is the conventional launcher.
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}


### PR DESCRIPTION
## Summary

Adds a startup prompt that notifies players when a newer GitHub release exists, with three choices: open the release page, remind me next time, or skip this version. Released binaries learn their own version via `-X main.Version=${GITHUB_REF_NAME}` in the release workflow; dev builds (`Version == "dev"`) skip the check entirely.

## How it flows

1. On `meowmine` startup, a goroutine hits `api.github.com/repos/.../releases/latest` with a 3s context timeout.
2. If the response parses and the tag is strictly newer than the embedded `main.Version`, and the tag is not present in `~/.meowmine/dismissed_versions.txt`, the goroutine dispatches `ui.UpdateAvailableMsg` into the tea program.
3. The App enters a new `splashUpdate` phase (before `splashName` / `splashDifficulty`). The panel shows current/latest version, a truncated markdown-stripped changelog (~12 lines), the release URL, and three options.
4. Keys: `[Up/Down]` + `[Enter]` mirrors the difficulty splash. Hotkeys `[y]` open release page, `[n]` session-dismiss, `[s]` skip this version (persists to file), `[o]` open release notes, `[Ctrl+C]` quit.

## Design decisions

- **No self-updating.** Opening the release page via `open` / `xdg-open` / `rundll32` is the honest UX for a cross-platform Go binary. No new dependencies pulled in.
- **Silent on failure.** Offline, timeout, HTTP error, malformed tag, prerelease, or same-version — all resolve to zero user-visible output. Silence is the feature.
- **Fail-closed semver.** Minimal int-wise comparison; unparseable tags never trigger the prompt.
- **Dismissed versions live outside game State.** They're cross-run meta-config, stored at `~/.meowmine/dismissed_versions.txt` alongside the save.
- **SSH binary does not run the check.** Multiplayer server doesn't own the player's browser; only `meowmine` calls `runStartupUpdateCheck`.

## Test plan

- [ ] `go vet ./...` clean
- [ ] `go test ./...` passes (includes new `core/update` tests: semver ordering, markdown stripping, dismiss file round-trip)
- [ ] `go build ./...` succeeds for both binaries
- [ ] Manual: run `go run ./cmd/meowmine` — no update prompt appears (dev build)
- [ ] Manual: build with `-ldflags "-X main.Version=v0.0.1"` and launch with network — update prompt appears with latest release notes
- [ ] Manual: in update prompt, press `[s]`, relaunch — prompt is silenced for that tag
- [ ] Manual: launch without network — game boots normally with no error