### PR TITLE
fix: store GPU label showed raw efficiency, not actual ₿/s

### DIFF
--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -208,7 +208,7 @@ var enStrings = map[string]string{
 	"prestige.perk_owned": "owned / maxed",
 
 	// Small labels used across multiple views.
-	"label.eff":       "eff %.4f ₿/s",
+	"label.eff":       "₿%.3f/s",
 	"label.bp_line":   "    eff %.4f ₿/s · %.0fV · %.0f°C · %.0fh durability",
 
 	// Event popup prompts.

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -208,7 +208,7 @@ var zhStrings = map[string]string{
 	"prestige.perk_owned":   "已拥有 / 满级",
 
 	// Small labels used across multiple views.
-	"label.eff":     "效率 %.4f ₿/秒",
+	"label.eff":     "₿%.3f/秒",
 	"label.bp_line": "    效率 %.4f ₿/秒 · %.0fV · %.0f°C · %.0fh 耐久",
 
 	// Event popup prompts.

--- a/ui/store.go
+++ b/ui/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 )
 
@@ -53,7 +54,7 @@ func (a App) renderStore() string {
 			name,
 			priceStyle.Render(fmt.Sprintf("₿%-6d", g.Price)),
 			DimStyle.Render(fmt.Sprintf("%s   %.0fV   %dh",
-				i18n.T("label.eff", g.Efficiency), g.PowerDraw, g.DurabilityHours)),
+				i18n.T("label.eff", g.Efficiency*game.MiningScale), g.PowerDraw, g.DurabilityHours)),
 		))
 	}
 


### PR DESCRIPTION
## Summary
- The store rendered \`g.Efficiency\` directly and labeled it "₿/s". For a GTX 1060 that shows "0.0012 ₿/s", but the actual earn rate is \`efficiency × MiningScale (300) × mults\` — so the card really mints ₿0.36/s baseline, and a 1060 Ti on easy difficulty with an upgrade can hit ₿0.9/s. 300× gap between label and reality.
- Multiply by \`game.MiningScale\` in the store render so shoppers see the real per-second BTC yield.
- Tighten the format to \`₿%.3f/s\` so the number stays readable across the 0.15–12 range of GPU tiers.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [ ] Open store in-game: confirm GTX 1060 now reads "₿0.360/s" not "eff 0.0012 ₿/s", and the number matches the dashboard earn rate once you buy it.