### PR TITLE
feat: headless simulator + --debug flag for self-verifying core changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Go build artifacts
 /meowmine
 /meowmine.exe
+/meowmine-ssh
+/meowmine-sim
 /dist/
 /bin/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md — kitten-crypto-mining-ventures
+
+Project-local notes for Claude. Workspace-level rules live at `/Users/jacksonc/i/CLAUDE.md`.
+
+## Ralph-loop mindset: self-verify core changes
+
+**If your change touches `core/game/` — you verify it before reporting done. Do not push "please try this and tell me if it looks right" to the user.** The simulator, `sim_test.go` helpers, and `--debug` mode exist so you can close the feedback loop yourself.
+
+The non-negotiable loop for any `core/game/` edit:
+
+1. **Run the unit tests** — `go test ./core/game/`. Must pass.
+2. **Run the simulator for an hour** — `./bin/meowmine-sim --ticks=3600 --seed=1` (build it first if `bin/meowmine-sim` is stale). Read the stderr summary; cross-check BTC / LifetimeEarned / GPU counts against your mental model of what should have changed. If a number looks wrong, that's the bug — investigate, don't ship.
+3. **Re-roll the dice** — same command with `--seed=2` and `--seed=3`. Crashes, NaN, or wildly different magnitudes across seeds usually mean an unseeded edge case or a math path that only fires on specific rolls.
+4. **If the change is load-bearing, lock it in with a test** — add a case to `core/game/sim_test.go` using `runSim(t, seed, ticks)`. Future sessions (including you) will thank you when they regress it six commits from now. Target the *invariant* you care about (e.g. "billing never drains more than X per hour at this difficulty"), not the exact numbers.
+
+Escalate to the user only when the sim disagrees with the design doc (`docs/GAME_DESIGN.md`) and you can't tell which side is wrong, or when a change crosses a design-level decision the user owns (balance thresholds, new mechanics, difficulty curves). Mechanical "does Tick still work" questions — you answer yourself.
+
+Apply the workspace-level Ralph-loop rules the same way you would elsewhere: search before implementing, no placeholder `// TODO` stubs in shipped code, max three failed approaches before surfacing, scope confined to this project.
+
+## Project shape
+
+- Bubble Tea TUI game. Entry: `cmd/meowmine` (local), `cmd/meowmine-ssh` (remote), `cmd/meowmine-sim` (headless simulator).
+- Game engine is pure Go under `core/game/` — no UI dependencies. `State.Tick(now int64)` is the single step function; `now` is virtual unix-seconds.
+- UI lives under `ui/`. The tea loop in `ui/app.go` calls `state.Tick(time.Now().Unix())` once per second.
+- RNG is the global `math/rand`. Seed via `game.SeedRNG(seed int64)` before touching state if you want reproducibility.
+
+## How to debug & verify game logic
+
+There are three layers. Reach for the lightest one that works.
+
+### 1. Unit tests (`go test ./core/game/`)
+
+Use these for focused assertions on a single system (billing, research, events). Existing pattern: construct `NewState`, manipulate timestamps, call the targeted method or `Tick`, assert on fields. See `economy_test.go`, `research_test.go`, `events_test.go`.
+
+`withTempHome(t)` reroutes HOME so save/legacy writes don't touch your real files — call it at the top of any test that might hit disk.
+
+### 2. Simulator-style tests (`core/game/sim_test.go`)
+
+For regressions that only appear over many ticks (economy balance, modifier churn, GPU wear, billing cadence), use the `runSim(t, seed, ticks)` helper. It mirrors the `cmd/meowmine-sim` inner loop exactly — same fixed epoch, same `SeedRNG` → same `Tick` → same `MaybeFireEvent` sequence.
+
+When you suspect a bug shows up only after minutes of play, add a case here rather than the binary — it runs in CI and keeps the failure reproducible.
+
+### 3. Simulator binary (`cmd/meowmine-sim`)
+
+For exploratory debugging, balance-eyeballing, or "does this new modifier explode after an hour":
+
+```sh
+make build-sim                                       # -> bin/meowmine-sim
+./bin/meowmine-sim --ticks=3600 --seed=1             # 1 virtual hour, stdout snapshot, stderr summary
+./bin/meowmine-sim --ticks=86400 --seed=1 --out=/tmp/day.json   # 24h; summary + full JSON
+./bin/meowmine-sim --from=~/.meowmine/save.json --ticks=3600    # advance an existing save
+./bin/meowmine-sim --ticks=3600 --seed=1 --snapshot-every=600 --out=/tmp/sim.json   # periodic snapshots
+```
+
+The summary on stderr is the fastest sanity signal: check `BTC`, `LifetimeEarned`, GPU counts, `Modifiers active`. If a number looks absurd, diff two snapshots (`diff /tmp/a.json /tmp/b.json`) to pinpoint the diverging field.
+
+**Known non-determinism:** `ShipsAt`, log entry `time`, and a couple of modifier expirations use `time.Now()` directly (not the virtual `now`). Game-mechanical fields are deterministic across same-seed runs; timestamps inside the snapshot can drift by seconds.
+
+### 4. `--debug` flag on the TUI
+
+For reproducing a UI-level bug interactively, or reaching a specific state fast:
+
+```sh
+make run-debug                # go run ./cmd/meowmine --debug
+./bin/meowmine --debug --debug-seed=42
+```
+
+Runtime keys (only when `--debug` is set):
+
+| Key | Action |
+| --- | --- |
+| `Ctrl+F` | Cycle sim speed: 1× → 4× → 16× → 64× → 1× |
+| `Ctrl+D` | Dump full state JSON to `/tmp/meowmine-debug-<unix>.json` |
+| `Ctrl+Y` | Cheat: +₿1 |
+| `Ctrl+T` | Cheat: +10 TechPoint |
+| `Ctrl+B` | Toggle the debug HUD line |
+
+Debug mode is **local only** — the SSH binary never calls `EnableDebug`, so remote sessions can't use cheats or time acceleration.
+
+## Common verification loop
+
+When you change tick-loop behavior:
+
+1. `go test ./core/game/` — catches unit regressions.
+2. `./bin/meowmine-sim --ticks=3600 --seed=1 --summary` — does the summary still look reasonable?
+3. If behaviour depends on event rolls, try 2–3 seeds (`--seed=1`, `--seed=2`, `--seed=3`) — should see varied outcomes but no crashes / NaN.
+4. If the change is UI-facing, `make run-debug` and drive it with `Ctrl+F` to reach the affected state quickly.
+
+## Don't
+
+- Don't thread `*rand.Rand` through `State` just to make the sim byte-deterministic. The existing global `rand` + `SeedRNG` is intentional; see `events_test.go` for the established pattern.
+- Don't write to `~/.meowmine/save.json` from tests. Use `withTempHome(t)`.
+- Don't add UI imports to `core/game`. The headless sim depends on that separation.

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@
 BIN_DIR := bin
 LOCAL   := $(BIN_DIR)/meowmine
 SSH     := $(BIN_DIR)/meowmine-ssh
+SIM     := $(BIN_DIR)/meowmine-sim
 
-.PHONY: help build run ssh test lint vet tidy clean
+.PHONY: help build build-sim run run-sim run-debug ssh test lint vet tidy clean
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*##"}; /^[a-zA-Z_-]+:.*##/ { printf "  %-12s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -12,13 +13,24 @@ help: ## Show this help
 tidy: ## Run go mod tidy (fetches deps, regenerates go.sum)
 	go mod tidy
 
-build: ## Build both binaries into bin/
+build: ## Build all three binaries into bin/
 	@mkdir -p $(BIN_DIR)
 	go build -o $(LOCAL) ./cmd/meowmine
 	go build -o $(SSH)   ./cmd/meowmine-ssh
+	go build -o $(SIM)   ./cmd/meowmine-sim
+
+build-sim: ## Build only the headless simulator
+	@mkdir -p $(BIN_DIR)
+	go build -o $(SIM) ./cmd/meowmine-sim
 
 run: ## Run the local TUI (equivalent to: go run ./cmd/meowmine)
 	go run ./cmd/meowmine
+
+run-debug: ## Run the local TUI with --debug (time multiplier + HUD + cheats)
+	go run ./cmd/meowmine --debug
+
+run-sim: ## Run the headless simulator for 1h of virtual time (seed=1)
+	go run ./cmd/meowmine-sim --ticks=3600 --seed=1
 
 ssh: build ## Build and run the SSH server on :23234
 	./$(SSH)
@@ -35,7 +47,7 @@ release: ## Cross-compile stripped release binaries for win/linux/macOS x64+arm6
 	@mkdir -p $(BIN_DIR)
 	@for target in "windows amd64 .exe" "linux amd64 " "darwin amd64 " "darwin arm64 "; do \
 		set -- $$target; os=$$1; arch=$$2; ext=$$3; \
-		for cmd in meowmine meowmine-ssh; do \
+		for cmd in meowmine meowmine-ssh meowmine-sim; do \
 			echo "  building $$cmd-$$os-$$arch$$ext"; \
 			GOOS=$$os GOARCH=$$arch go build -ldflags "-s -w" \
 				-o $(BIN_DIR)/$$cmd-$$os-$$arch$$ext ./cmd/$$cmd; \

--- a/cmd/meowmine-sim/main.go
+++ b/cmd/meowmine-sim/main.go
@@ -1,0 +1,162 @@
+// meowmine-sim is a headless simulator for the kitten-crypto-mining-ventures
+// game. It drives game.State.Tick against virtual time (no UI, no sleeps),
+// which lets us run 1h / 1d / 1w of game time in seconds and dump snapshots
+// for inspection or regression-diffing.
+//
+// Examples:
+//
+//	meowmine-sim --ticks=3600 --seed=1 --out=/tmp/sim.json
+//	meowmine-sim --from=~/.meowmine/save.json --ticks=86400 --out=-
+//	meowmine-sim --ticks=3600 --seed=1 --snapshot-every=600 --out=/tmp/sim
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
+)
+
+// fixedBaseUnix is the virtual-time origin for fresh sims. Choosing a fixed
+// epoch (rather than time.Now) keeps runs reproducible across invocations.
+const fixedBaseUnix int64 = 1_700_000_000
+
+func main() {
+	ticks := flag.Int("ticks", 3600, "number of 1-second virtual ticks to advance")
+	seed := flag.Int64("seed", 1, "RNG seed (deterministic across runs with same seed)")
+	from := flag.String("from", "", "optional save file to start from; empty = fresh NewState")
+	kittenName := flag.String("name", "sim-kitten", "kitten name for a fresh sim (ignored if --from set)")
+	difficulty := flag.String("difficulty", "normal", "difficulty for a fresh sim (ignored if --from set)")
+	out := flag.String("out", "-", "final snapshot destination; \"-\" for stdout")
+	snapshotEvery := flag.Int("snapshot-every", 0, "if >0, also write a snapshot every N ticks to <out>.<tick>.json")
+	summary := flag.Bool("summary", true, "print a human summary to stderr on completion")
+	flag.Parse()
+
+	if *ticks < 0 {
+		fmt.Fprintln(os.Stderr, "--ticks must be >= 0")
+		os.Exit(2)
+	}
+	if *snapshotEvery > 0 && *out == "-" {
+		fmt.Fprintln(os.Stderr, "--snapshot-every requires --out to be a file path, not '-'")
+		os.Exit(2)
+	}
+
+	game.SeedRNG(*seed)
+
+	state, err := loadOrNew(*from, *kittenName, *difficulty)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load: %v\n", err)
+		os.Exit(1)
+	}
+
+	startBTC := state.BTC
+	startLifetime := state.LifetimeEarned
+	startTech := state.TechPoint
+	startLogLen := len(state.Log)
+	baseUnix := state.LastTickUnix
+
+	for i := 1; i <= *ticks; i++ {
+		state.Tick(baseUnix + int64(i))
+		// Drive event rolls too — in the real UI this happens right after Tick.
+		_ = state.MaybeFireEvent()
+		if *snapshotEvery > 0 && i%*snapshotEvery == 0 {
+			path := snapshotPath(*out, i)
+			if err := writeJSON(path, state); err != nil {
+				fmt.Fprintf(os.Stderr, "snapshot %s: %v\n", path, err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	if err := writeJSON(*out, state); err != nil {
+		fmt.Fprintf(os.Stderr, "write final: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *summary {
+		printSummary(os.Stderr, state, *ticks, *seed, startBTC, startLifetime, startTech, startLogLen)
+	}
+}
+
+func loadOrNew(from, kittenName, difficulty string) (*game.State, error) {
+	if from == "" {
+		s := game.NewState(kittenName)
+		s.SetDifficulty(difficulty)
+		// Pin every timestamp to a fixed epoch so two fresh runs with the same
+		// seed produce identical state (save for log wall-clock timestamps,
+		// which are stamped via time.Now inside appendLog).
+		s.LastTickUnix = fixedBaseUnix
+		s.LastBillUnix = fixedBaseUnix
+		s.LastWagesUnix = fixedBaseUnix
+		s.StartedUnix = fixedBaseUnix
+		return s, nil
+	}
+	path := expandHome(from)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return game.LoadFrom(b)
+}
+
+func expandHome(p string) string {
+	if strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+func snapshotPath(out string, tick int) string {
+	// <out>.<tick>.json — strip a trailing .json on <out> if present so the
+	// tick number isn't sandwiched awkwardly between two extensions.
+	base := strings.TrimSuffix(out, ".json")
+	return fmt.Sprintf("%s.%d.json", base, tick)
+}
+
+func writeJSON(dst string, state *game.State) error {
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	if dst == "-" {
+		_, err = os.Stdout.Write(append(b, '\n'))
+		return err
+	}
+	if dir := filepath.Dir(dst); dir != "" {
+		_ = os.MkdirAll(dir, 0o755)
+	}
+	return os.WriteFile(dst, b, 0o644)
+}
+
+func printSummary(w *os.File, s *game.State, ticks int, seed int64, startBTC, startLifetime float64, startTech, startLogLen int) {
+	gpuRunning, gpuShipping, gpuBroken := 0, 0, 0
+	for _, g := range s.GPUs {
+		switch g.Status {
+		case "shipping":
+			gpuShipping++
+		case "broken", "stolen", "offline":
+			gpuBroken++
+		default:
+			gpuRunning++
+		}
+	}
+	fmt.Fprintf(w, "── sim summary ──────────────────────────────\n")
+	fmt.Fprintf(w, " ticks:            %d (seed=%d)\n", ticks, seed)
+	fmt.Fprintf(w, " virtual time:     %ds -> %ds\n", s.LastTickUnix-int64(ticks), s.LastTickUnix)
+	fmt.Fprintf(w, " BTC:              %.4f  (Δ %+.4f)\n", s.BTC, s.BTC-startBTC)
+	fmt.Fprintf(w, " LifetimeEarned:   %.4f  (Δ %+.4f)\n", s.LifetimeEarned, s.LifetimeEarned-startLifetime)
+	fmt.Fprintf(w, " TechPoint:        %d  (Δ %+d)\n", s.TechPoint, s.TechPoint-startTech)
+	fmt.Fprintf(w, " Reputation:       %d\n", s.Reputation)
+	fmt.Fprintf(w, " GPUs:             %d running, %d shipping, %d broken\n", gpuRunning, gpuShipping, gpuBroken)
+	fmt.Fprintf(w, " Mercs:            %d\n", len(s.Mercs))
+	fmt.Fprintf(w, " Blueprints:       %d\n", len(s.Blueprints))
+	fmt.Fprintf(w, " Modifiers active: %d\n", len(s.Modifiers))
+	fmt.Fprintf(w, " Log entries:      +%d (total %d)\n", len(s.Log)-startLogLen, len(s.Log))
+	fmt.Fprintf(w, "─────────────────────────────────────────────\n")
+}

--- a/cmd/meowmine/main.go
+++ b/cmd/meowmine/main.go
@@ -21,7 +21,13 @@ var Version = "dev"
 
 func main() {
 	newGame := flag.Bool("new", false, "start a new game, discarding any save")
+	debug := flag.Bool("debug", false, "enable debug mode: time multiplier, state dump, cheat keys, HUD")
+	debugSeed := flag.Int64("debug-seed", 0, "if non-zero and --debug is set, seed the RNG for reproducible runs")
 	flag.Parse()
+
+	if *debug && *debugSeed != 0 {
+		game.SeedRNG(*debugSeed)
+	}
 
 	var state *game.State
 	if !*newGame {
@@ -44,13 +50,18 @@ func main() {
 		state.RunOfflineCatchup(time.Now().Unix())
 	}
 
-	p := tea.NewProgram(ui.NewApp(state), tea.WithAltScreen())
+	app := ui.NewApp(state)
+	if *debug {
+		app.EnableDebug()
+	}
+	p := tea.NewProgram(app, tea.WithAltScreen())
 
 	// Fire the update check in a goroutine BEFORE the tea Program runs.
 	// Once it resolves we deliver the result via p.Send so the App
 	// transitions into the splashUpdate phase. Anything that fails
 	// (offline, HTTP error, same version, dismissed tag) is silent.
 	go runStartupUpdateCheck(p)
+
 
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "ui error: %v\n", err)

--- a/core/game/sim.go
+++ b/core/game/sim.go
@@ -1,0 +1,9 @@
+package game
+
+import "math/rand"
+
+// SeedRNG seeds the global math/rand source used throughout the simulation
+// (shipping delays, scrap fragments, upgrade failures, event rolls). Call this
+// before touching state if you want reproducible runs — matches the seeding
+// pattern already used in core/game tests.
+func SeedRNG(seed int64) { rand.Seed(seed) }

--- a/core/game/sim_test.go
+++ b/core/game/sim_test.go
@@ -1,0 +1,114 @@
+package game
+
+import (
+	"math"
+	"testing"
+)
+
+// simTestBaseUnix matches the fixed epoch used by cmd/meowmine-sim, so tests
+// and the binary exercise the same pinned-time progression.
+const simTestBaseUnix int64 = 1_700_000_000
+
+// runSim mirrors cmd/meowmine-sim's inner loop: seed the RNG, pin every
+// timestamp to a fixed epoch, advance N virtual seconds via Tick + event
+// rolls. Kept package-private so the test file is the only caller.
+func runSim(t *testing.T, seed int64, ticks int) *State {
+	t.Helper()
+	SeedRNG(seed)
+	s := NewState("sim-test")
+	s.SetDifficulty("normal")
+	s.LastTickUnix = simTestBaseUnix
+	s.LastBillUnix = simTestBaseUnix
+	s.LastWagesUnix = simTestBaseUnix
+	s.StartedUnix = simTestBaseUnix
+	for i := 1; i <= ticks; i++ {
+		s.Tick(simTestBaseUnix + int64(i))
+		_ = s.MaybeFireEvent()
+	}
+	return s
+}
+
+// TestSimLongRunSanity catches the class of regression the simulator exists
+// for: a broken tick path that silently produces NaN earnings, leaves the
+// clock stuck, or skips the billing subsystem entirely.
+func TestSimLongRunSanity(t *testing.T) {
+	withTempHome(t)
+	s := runSim(t, 1, 3600) // 1 virtual hour
+
+	if math.IsNaN(s.BTC) || math.IsInf(s.BTC, 0) {
+		t.Fatalf("BTC became non-finite: %v", s.BTC)
+	}
+	if math.IsNaN(s.LifetimeEarned) || s.LifetimeEarned < 0 {
+		t.Fatalf("LifetimeEarned invalid: %v", s.LifetimeEarned)
+	}
+	wantTick := simTestBaseUnix + 3600
+	if s.LastTickUnix != wantTick {
+		t.Fatalf("LastTickUnix = %d, want %d", s.LastTickUnix, wantTick)
+	}
+	// Billing fires every 60s. After an hour we expect LastBillUnix to have
+	// moved off its starting value — if it hasn't, advanceBilling isn't
+	// being reached.
+	if s.LastBillUnix <= simTestBaseUnix {
+		t.Errorf("billing never advanced in 1h of ticks (LastBillUnix=%d)", s.LastBillUnix)
+	}
+	// Starter GPU should still exist (may be running or broken, but not gone).
+	if len(s.GPUs) == 0 {
+		t.Error("GPU list emptied itself during tick loop")
+	}
+}
+
+// TestSimDeterministicGameState asserts that two fresh runs with the same
+// seed produce identical *game* fields. Timestamp fields stamped via
+// time.Now() inside appendLog/ShipsAt drift by milliseconds between runs and
+// are intentionally excluded — this test is about game logic determinism,
+// not wall-clock bookkeeping.
+func TestSimDeterministicGameState(t *testing.T) {
+	withTempHome(t)
+	a := runSim(t, 42, 1800)
+	withTempHome(t)
+	b := runSim(t, 42, 1800)
+
+	if a.BTC != b.BTC {
+		t.Errorf("BTC drift: %v vs %v", a.BTC, b.BTC)
+	}
+	if a.LifetimeEarned != b.LifetimeEarned {
+		t.Errorf("LifetimeEarned drift: %v vs %v", a.LifetimeEarned, b.LifetimeEarned)
+	}
+	if a.TechPoint != b.TechPoint {
+		t.Errorf("TechPoint drift: %d vs %d", a.TechPoint, b.TechPoint)
+	}
+	if a.Reputation != b.Reputation {
+		t.Errorf("Reputation drift: %d vs %d", a.Reputation, b.Reputation)
+	}
+	if a.Karma != b.Karma {
+		t.Errorf("Karma drift: %d vs %d", a.Karma, b.Karma)
+	}
+	if len(a.GPUs) != len(b.GPUs) {
+		t.Errorf("GPU count drift: %d vs %d", len(a.GPUs), len(b.GPUs))
+	}
+	if len(a.Modifiers) != len(b.Modifiers) {
+		t.Errorf("Modifier count drift: %d vs %d", len(a.Modifiers), len(b.Modifiers))
+	}
+	if len(a.Achievements) != len(b.Achievements) {
+		t.Errorf("Achievement count drift: %d vs %d", len(a.Achievements), len(b.Achievements))
+	}
+}
+
+// TestSimSeedsDiverge proves that seeding actually threads into the game —
+// if somebody refactored RNG calls to use a non-seeded source, this catches
+// it by observing that two seeds produce at least one different outcome.
+func TestSimSeedsDiverge(t *testing.T) {
+	withTempHome(t)
+	a := runSim(t, 1, 1800)
+	withTempHome(t)
+	b := runSim(t, 2, 1800)
+
+	same := a.BTC == b.BTC &&
+		a.Reputation == b.Reputation &&
+		a.TechPoint == b.TechPoint &&
+		len(a.Log) == len(b.Log) &&
+		len(a.Modifiers) == len(b.Modifiers)
+	if same {
+		t.Fatal("seed=1 and seed=2 produced identical observable state — RNG is probably not being threaded through")
+	}
+}

--- a/ui/app.go
+++ b/ui/app.go
@@ -96,6 +96,10 @@ type App struct {
 	// Picked up once in NewApp and cleared as soon as the player dismisses
 	// it — any subsequent launches regenerate it fresh.
 	showOfflineSummary *game.OfflineSummary
+
+	// debug is populated only when EnableDebug() is called (local --debug
+	// flag). SSH sessions leave this zero-valued and all debug paths no-op.
+	debug debugState
 }
 
 func NewApp(s *game.State) App {
@@ -142,7 +146,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		if a.splashPhase == splashNone {
-			a.state.Tick(time.Now().Unix())
+			// In debug mode with a time multiplier, advance virtual time
+			// faster than wall clock: each real second of multiplier=N
+			// advances N virtual seconds. offset accumulates so the
+			// progression remains monotonic across repeated ticks.
+			if a.debug.enabled && a.debug.timeMult > 1 {
+				a.debug.virtualOffset += int64(a.debug.timeMult - 1)
+			}
+			a.state.Tick(time.Now().Unix() + a.debug.virtualOffset)
 			if def := a.state.MaybeFireEvent(); def != nil {
 				a.showEventPopup = def
 			}
@@ -239,6 +250,11 @@ func (a App) handleDifficultyEntry(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (a App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if a.debug.enabled {
+		if na, cmd, handled := a.handleDebugKey(k); handled {
+			return na, cmd
+		}
+	}
 	key := k.String()
 	// Universal keys.
 	switch key {
@@ -385,7 +401,11 @@ func (a App) View() string {
 
 	footer := a.renderFooter()
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, nav, body, footer)
+	parts := []string{header, nav, body, footer}
+	if hud := a.debugHUDLine(); hud != "" {
+		parts = append(parts, hud)
+	}
+	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
 
 	// On dashboard, notifications render as an inline right-hand panel
 	// (see renderDashboard). On other views we still fall back to the

--- a/ui/debug.go
+++ b/ui/debug.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// debugState holds runtime-debug affordances. It's only populated when
+// cmd/meowmine is started with --debug. Everything here is intentionally
+// local-only: the SSH server never calls EnableDebug, so cheats and time
+// acceleration can't reach remote sessions.
+type debugState struct {
+	enabled       bool
+	hudVisible    bool
+	timeMult      int   // 1, 4, 16, 64 — applied to virtual-time advance per tick
+	virtualOffset int64 // accumulated extra seconds beyond wall clock
+	lastDumpPath  string
+}
+
+// timeMultCycle returns the next value in the rotation.
+func timeMultCycle(cur int) int {
+	switch cur {
+	case 1:
+		return 4
+	case 4:
+		return 16
+	case 16:
+		return 64
+	default:
+		return 1
+	}
+}
+
+// EnableDebug flips the app into debug mode. Idempotent.
+func (a *App) EnableDebug() {
+	a.debug.enabled = true
+	a.debug.hudVisible = true
+	if a.debug.timeMult == 0 {
+		a.debug.timeMult = 1
+	}
+}
+
+// handleDebugKey routes a keypress to a debug action. Returns (updatedModel,
+// cmd, handled) — when handled=false, the caller should fall through to the
+// normal key pipeline. Only called when debug mode is enabled.
+func (a App) handleDebugKey(k tea.KeyMsg) (App, tea.Cmd, bool) {
+	switch k.String() {
+	case "ctrl+f":
+		a.debug.timeMult = timeMultCycle(a.debug.timeMult)
+		a = a.withStatus(fmt.Sprintf("⏩ debug: sim speed ×%d", a.debug.timeMult))
+		return a, nil, true
+	case "ctrl+d":
+		path, err := a.dumpDebugState()
+		if err != nil {
+			a = a.withStatus("debug dump failed: " + err.Error())
+		} else {
+			a.debug.lastDumpPath = path
+			a = a.withStatus("📸 debug dump → " + path)
+		}
+		return a, nil, true
+	case "ctrl+b":
+		a.debug.hudVisible = !a.debug.hudVisible
+		return a, nil, true
+	case "ctrl+y":
+		// Cheat: add 1 BTC. `ctrl+m` is equivalent to Enter in many
+		// terminals, which would conflict with normal input — use ctrl+y
+		// instead ("yarn").
+		a.state.BTC += 1
+		a = a.withStatus("🐾 debug: +₿1")
+		return a, nil, true
+	case "ctrl+t":
+		a.state.TechPoint += 10
+		a = a.withStatus("🧠 debug: +10 TP")
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+// dumpDebugState writes the full state as JSON to /tmp with a timestamped
+// filename and returns the path. Uses SaveAs under the hood so it matches the
+// on-disk save format exactly.
+func (a App) dumpDebugState() (string, error) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("meowmine-debug-%d.json", time.Now().Unix()))
+	if err := a.state.SaveAs(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// debugHUDLine renders the one-line debug HUD. Returns "" when disabled or
+// hidden so callers can concat unconditionally.
+func (a App) debugHUDLine() string {
+	if !a.debug.enabled || !a.debug.hudVisible {
+		return ""
+	}
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("#ff8800"))
+	info := fmt.Sprintf(
+		"🛠 debug  tick=%d  mult=×%d  offset=+%ds  BTC=%.2f  TP=%d  mods=%d",
+		a.state.LastTickUnix,
+		a.debug.timeMult,
+		a.debug.virtualOffset,
+		a.state.BTC,
+		a.state.TechPoint,
+		len(a.state.Modifiers),
+	)
+	if a.debug.lastDumpPath != "" {
+		info += "  dump=" + a.debug.lastDumpPath
+	}
+	return style.Render(info)
+}
+


### PR DESCRIPTION
## Summary
- Adds `cmd/meowmine-sim` — a headless simulator that drives `State.Tick` over virtual time. 24h of game-time runs in seconds. Flags: `--ticks --seed --from --out --snapshot-every --summary`. Useful for balance-eyeballing, long-run regression checks, and advancing an existing save without the UI.
- Adds a local-only `--debug` flag on `cmd/meowmine`: `Ctrl+F` cycles sim speed 1× → 4× → 16× → 64×, `Ctrl+D` dumps state JSON, `Ctrl+B` toggles a debug HUD, `Ctrl+Y`/`Ctrl+T` are small cheats for fast-forwarding to mid-game states. SSH binary is untouched — cheats stay local.
- Adds `core/game/sim.go` with a single `SeedRNG(int64)` helper and `core/game/sim_test.go` with three tick-loop regression tests (long-run sanity, same-seed determinism on game fields, cross-seed divergence).
- Adds `CLAUDE.md` at the repo root codifying a Ralph-loop mindset: if you change `core/game/`, run the sim + tests yourself instead of asking the user to verify.

## Tradeoffs / follow-ups
- Timestamp fields written via `time.Now()` inside `appendLog`, `ShipsAt`, and a couple of modifier expirations still drift by seconds between runs. Game-mechanical fields are fully deterministic; snapshot JSON is not byte-identical. Noted in `CLAUDE.md`. Making snapshots byte-identical would require threading `now` into every state-mutating call — not done here.
- Scenario scripting (`--scenario=foo.json` driving specific purchases/research) deferred until we see what we actually need to reproduce.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all prior tests + 3 new `TestSim*` cases pass (~60ms)
- [x] `./bin/meowmine-sim --ticks=86400 --seed=1` runs 24 virtual hours in under a second, summary looks sane
- [x] `--from=<save>` continues an existing snapshot; virtual time advances correctly
- [x] `--snapshot-every=250` writes interval snapshots
- [x] Different seeds (`--seed=1` vs `--seed=2`) produce different BTC/reputation
- [ ] Reviewer: `make run-debug` locally and verify `Ctrl+F` / `Ctrl+D` / `Ctrl+B` behave (can't be automated without a real TTY)