### PR TITLE
feat: rescale displayed BTC by 300x (display-only)

### DIFF
--- a/core/game/btcfmt.go
+++ b/core/game/btcfmt.go
@@ -1,0 +1,58 @@
+package game
+
+import "fmt"
+
+// DisplayScale is applied to raw BTC values before they are shown to the
+// player. Internal math (state.BTC, JSON prices, MiningScale) operates on
+// unscaled units; this keeps save files compatible while letting the UI
+// feel like actual BTC — a GTX 1060 displays as ₿0.4, earns ~₿0.0012/s.
+const DisplayScale = 300.0
+
+// FmtBTC formats a raw balance amount with adaptive precision suited to
+// post-rescale magnitudes. Handles negatives with a leading minus.
+func FmtBTC(raw float64) string {
+	v := raw / DisplayScale
+	sign := ""
+	if v < 0 {
+		sign = "-"
+		v = -v
+	}
+	switch {
+	case v < 0.001:
+		return fmt.Sprintf("%s₿%.5f", sign, v)
+	case v < 1:
+		return fmt.Sprintf("%s₿%.4f", sign, v)
+	case v < 100:
+		return fmt.Sprintf("%s₿%.3f", sign, v)
+	case v < 10000:
+		return fmt.Sprintf("%s₿%.2f", sign, v)
+	default:
+		return fmt.Sprintf("%s₿%.0f", sign, v)
+	}
+}
+
+// FmtBTCInt formats an integer BTC amount (typically JSON-sourced prices).
+func FmtBTCInt(raw int) string { return FmtBTC(float64(raw)) }
+
+// FmtBTCSigned always emits an explicit +/- so "net" readouts read as
+// deltas rather than absolute numbers. Zero renders as "+₿…".
+func FmtBTCSigned(raw float64) string {
+	v := raw / DisplayScale
+	sign := "+"
+	if v < 0 {
+		sign = "-"
+		v = -v
+	}
+	switch {
+	case v < 0.001:
+		return fmt.Sprintf("%s₿%.5f", sign, v)
+	case v < 1:
+		return fmt.Sprintf("%s₿%.4f", sign, v)
+	case v < 100:
+		return fmt.Sprintf("%s₿%.3f", sign, v)
+	case v < 10000:
+		return fmt.Sprintf("%s₿%.2f", sign, v)
+	default:
+		return fmt.Sprintf("%s₿%.0f", sign, v)
+	}
+}

--- a/core/game/events.go
+++ b/core/game/events.go
@@ -183,7 +183,7 @@ func (s *State) applyEvent(e data.EventDef) {
 			if s.BTC < 0 {
 				s.BTC = 0
 			}
-			s.appendLog("threat", i18n.T("log.event.fire.money", loss, frac*100))
+			s.appendLog("threat", i18n.T("log.event.fire.money", FmtBTC(loss), frac*100))
 		}
 	}
 }
@@ -293,7 +293,7 @@ func (s *State) RepairGPU(instanceID int) error {
 			cost = 0
 		}
 		if s.BTC < float64(cost) {
-			return fmt.Errorf("need ₿%d to repair", cost)
+			return fmt.Errorf("need %s to repair", FmtBTCInt(cost))
 		}
 		s.BTC -= float64(cost)
 		g.Status = "running"
@@ -302,7 +302,7 @@ func (s *State) RepairGPU(instanceID int) error {
 		if cost == 0 {
 			s.appendLog("info", i18n.T("log.event.repair.free"))
 		} else {
-			s.appendLog("info", i18n.T("log.event.repair.paid", cost))
+			s.appendLog("info", i18n.T("log.event.repair.paid", FmtBTCInt(cost)))
 		}
 		return nil
 	}

--- a/core/game/mercs.go
+++ b/core/game/mercs.go
@@ -16,7 +16,7 @@ func (s *State) HireMerc(defID string) error {
 		return fmt.Errorf("unknown merc")
 	}
 	if s.BTC < float64(def.HireCost) {
-		return fmt.Errorf("need ₿%d, have ₿%.0f", def.HireCost, s.BTC)
+		return fmt.Errorf("need %s, have %s", FmtBTCInt(def.HireCost), FmtBTC(s.BTC))
 	}
 	s.BTC -= float64(def.HireCost)
 	loyalty := def.LoyaltyBase + s.MercLoyaltyFloor()
@@ -32,7 +32,7 @@ func (s *State) HireMerc(defID string) error {
 	}
 	s.NextMercID++
 	s.Mercs = append(s.Mercs, m)
-	s.appendLog("info", i18n.T("log.merc.hired", def.LocalName(), def.HireCost))
+	s.appendLog("info", i18n.T("log.merc.hired", def.LocalName(), FmtBTCInt(def.HireCost)))
 	return nil
 }
 
@@ -56,7 +56,7 @@ func (s *State) FireMerc(instanceID int) error {
 func (s *State) BribeMerc(instanceID int) error {
 	const cost = 200
 	if s.BTC < cost {
-		return fmt.Errorf("need ₿%d", cost)
+		return fmt.Errorf("need %s", FmtBTCInt(cost))
 	}
 	for _, m := range s.Mercs {
 		if m.InstanceID == instanceID {
@@ -107,7 +107,7 @@ func (s *State) payWages(now int64) {
 		}
 	}
 	if totalWage > 0 {
-		s.appendLog("info", i18n.T("log.merc.wages", totalWage))
+		s.appendLog("info", i18n.T("log.merc.wages", FmtBTC(totalWage)))
 	}
 
 	// Random betrayal check — once per wage tick, one low-loyalty merc might flip.

--- a/core/game/prestige.go
+++ b/core/game/prestige.go
@@ -63,7 +63,7 @@ func (s *State) RetireReward() int {
 // Returns the NEW state (to swap in) and the LP awarded.
 func (s *State) Retire() (*State, int, error) {
 	if !s.CanRetire() {
-		return nil, 0, fmt.Errorf("need ₿%.0f lifetime earnings; have ₿%.0f", PrestigeThreshold, s.LifetimeEarned)
+		return nil, 0, fmt.Errorf("need %s lifetime earnings; have %s", FmtBTC(PrestigeThreshold), FmtBTC(s.LifetimeEarned))
 	}
 	lp := s.RetireReward()
 	legacy := LoadLegacy()

--- a/core/game/research.go
+++ b/core/game/research.go
@@ -59,7 +59,7 @@ func (s *State) StartResearch(tier int, boosts []string) error {
 		return fmt.Errorf("need %d research fragments, have %d", info.Frags, s.ResearchFrags)
 	}
 	if s.BTC < float64(info.Money) {
-		return fmt.Errorf("need ₿%d, have ₿%.0f", info.Money, s.BTC)
+		return fmt.Errorf("need %s, have %s", FmtBTCInt(info.Money), FmtBTC(s.BTC))
 	}
 	s.ResearchFrags -= info.Frags
 	s.BTC -= float64(info.Money)
@@ -142,7 +142,7 @@ func (s *State) PrintMEOWCore(blueprintID string) error {
 	cost := info.Money * 3 / 10
 	frags := info.Frags / 5
 	if s.BTC < float64(cost) {
-		return fmt.Errorf("need ₿%d to print", cost)
+		return fmt.Errorf("need %s to print", FmtBTCInt(cost))
 	}
 	if s.ResearchFrags < frags {
 		return fmt.Errorf("need %d fragments to print", frags)

--- a/core/game/state.go
+++ b/core/game/state.go
@@ -205,7 +205,7 @@ func newStateWithLegacy(kittenName string, legacy *LegacyStore) *State {
 	if legacy != nil {
 		if legacy.StarterCash > 0 {
 			s.BTC += legacy.StarterCash
-			s.appendLog("opportunity", i18n.T("log.legacy.cash", legacy.StarterCash))
+			s.appendLog("opportunity", i18n.T("log.legacy.cash", FmtBTC(legacy.StarterCash)))
 		}
 		if legacy.UnlockedUniversity {
 			if def, ok := data.RoomByID("university"); ok {
@@ -251,7 +251,7 @@ func (s *State) UnlockRoom(id string) error {
 		return fmt.Errorf("no such room: %s", id)
 	}
 	if s.BTC < float64(def.UnlockCost) {
-		return fmt.Errorf("need ₿%d, have ₿%.0f", def.UnlockCost, s.BTC)
+		return fmt.Errorf("need %s, have %s", FmtBTCInt(def.UnlockCost), FmtBTC(s.BTC))
 	}
 	s.BTC -= float64(def.UnlockCost)
 	s.unlockRoomInternal(def)
@@ -323,14 +323,14 @@ func (s *State) BuyGPU(defID string) error {
 		return fmt.Errorf("no such GPU: %s", defID)
 	}
 	if s.BTC < float64(def.Price) {
-		return fmt.Errorf("need ₿%d, have ₿%.0f", def.Price, s.BTC)
+		return fmt.Errorf("need %s, have %s", FmtBTCInt(def.Price), FmtBTC(s.BTC))
 	}
 	if !s.RoomHasFreeSlot(s.CurrentRoom) {
 		return fmt.Errorf("no free slots in this room")
 	}
 	s.BTC -= float64(def.Price)
 	s.addGPU(defID, s.CurrentRoom, true)
-	s.appendLog("info", i18n.T("log.gpu.ordered", def.LocalName(), def.Price))
+	s.appendLog("info", i18n.T("log.gpu.ordered", def.LocalName(), FmtBTCInt(def.Price)))
 	return nil
 }
 
@@ -354,7 +354,7 @@ func (s *State) SellGPU(instanceID int) error {
 			s.BTC += value
 			s.ResearchFrags += frags
 			s.GPUs = append(s.GPUs[:i], s.GPUs[i+1:]...)
-			s.appendLog("info", i18n.T("log.gpu.scrapped", name, value, frags))
+			s.appendLog("info", i18n.T("log.gpu.scrapped", name, FmtBTC(value), frags))
 			return nil
 		}
 	}

--- a/core/game/tick.go
+++ b/core/game/tick.go
@@ -219,7 +219,7 @@ func (s *State) advanceBilling(now int64) {
 	s.BTC -= totalBill
 	s.BTC -= totalRent
 	if totalBill+totalRent > 0 {
-		s.appendLog("info", i18n.T("log.bills.settled", totalBill, totalRent))
+		s.appendLog("info", i18n.T("log.bills.settled", FmtBTC(totalBill), FmtBTC(totalRent)))
 	}
 	if s.BTC < 0 {
 		s.BTC = 0
@@ -248,7 +248,7 @@ func (s *State) UpgradeGPU(instanceID int) error {
 		}
 		cost := price / 3
 		if s.BTC < float64(cost) {
-			return fmt.Errorf("need ₿%d, have ₿%.0f", cost, s.BTC)
+			return fmt.Errorf("need %s, have %s", FmtBTCInt(cost), FmtBTC(s.BTC))
 		}
 		s.BTC -= float64(cost)
 		failChance := 0.05 + 0.05*float64(g.UpgradeLevel)
@@ -280,7 +280,7 @@ func (s *State) EmergencyVent() error {
 		return fmt.Errorf("no room")
 	}
 	if s.BTC < EmergencyVentCost {
-		return fmt.Errorf("need ₿%d", EmergencyVentCost)
+		return fmt.Errorf("need %s", FmtBTCInt(EmergencyVentCost))
 	}
 	now := time.Now().Unix()
 	last := s.EventCooldown["vent:"+s.CurrentRoom]
@@ -295,7 +295,7 @@ func (s *State) EmergencyVent() error {
 		Kind:      "pause_mining",
 		ExpiresAt: now + 30,
 	})
-	s.appendLog("info", i18n.T("log.room.vent", EmergencyVentCost))
+	s.appendLog("info", i18n.T("log.room.vent", FmtBTCInt(EmergencyVentCost)))
 	return nil
 }
 
@@ -361,7 +361,7 @@ func (s *State) UpgradeDefense(dim string) error {
 	}
 	cost := (*lvl + 1) * 250
 	if s.BTC < float64(cost) {
-		return fmt.Errorf("need ₿%d, have ₿%.0f", cost, s.BTC)
+		return fmt.Errorf("need %s, have %s", FmtBTCInt(cost), FmtBTC(s.BTC))
 	}
 	s.BTC -= float64(cost)
 	*lvl++

--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -38,9 +38,9 @@ var enStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.line.volt":  "⚡ %.0fV draw  ·  bill −₿%.3f/s  ·  next bill %ds",
+	"dash.line.volt":  "⚡ %.0fV draw  ·  bill −%s/s  ·  next bill %ds",
 	"dash.line.heat":  "🌡 %.0f°C / %.0f max  ·  %+.1f°C every %ds  ·  next in %ds",
-	"dash.line.cash":  "📈 earn +₿%.3f/s  ·  net %+.3f/s",
+	"dash.line.cash":  "📈 earn +%s/s  ·  net %s/s",
 	"dash.slots_of":   "slots %d/%d",
 	"dash.heat.warning":  "\uf071 HOT — efficiency ½ · wear 3×",
 	"dash.heat.critical": "\uf06d CRITICAL — wear 8× · GPU failure imminent",
@@ -51,8 +51,8 @@ var enStrings = map[string]string{
 	"dash.power.safe":      "safe",
 	"dash.power.deficit":   "losing ₿/s — balance lasts %s",
 	"dash.power.broke":     "empty wallet → 60s blackout",
-	"dash.line.power":      "\uf0e7 %.0fV  −₿%.3f/s  (next bill %ds)",
-	"dash.line.cash2":      "\uf201 +₿%.3f/s earn   net %+.3f/s",
+	"dash.line.power":      "\uf0e7 %.0fV  −%s/s  (next bill %ds)",
+	"dash.line.cash2":      "\uf201 +%s/s earn   net %s/s",
 	"dash.heat.label":      "\uf2c7 Heat  %.0f/%.0f°C  %+.1f/%ds",
 	"dash.rack":           "GPU Rack",
 	"dash.empty_hint":     "  (empty — press [2] to go to the store)",
@@ -107,7 +107,7 @@ var enStrings = map[string]string{
 	"rooms.help":       "↑/↓ room   [u] unlock   [enter] switch   [l/c/w/o/a] upgrade defense on current room   [esc]/[1] back",
 	"rooms.here":       "● here",
 	"rooms.unlocked":   "unlocked",
-	"rooms.to_unlock":  "₿%d to unlock",
+	"rooms.to_unlock":  "%s to unlock",
 	"rooms.stats":      "  cooling %.1f · elec ×%.2f · threat base %.2f",
 	"rooms.defense":    "🛡  Defense — current room (%s)",
 	"rooms.dim.lock":    "Lock",
@@ -149,7 +149,7 @@ var enStrings = map[string]string{
 	"help.g.pump":     "[p]       Pump & Dump ability (dashboard, if unlocked)",
 	"help.g.lang":     "[L]       cycle language",
 	"help.g.quit":     "[q]       quit (auto-saves)",
-	"help.g.vent":     "[V]       emergency vent — reset room heat · -₿100 · 30s pause · 2m cooldown",
+	"help.g.vent":     "[V]       emergency vent — reset room heat · %s · 30s pause · 2m cooldown",
 	"help.defense":    "Room defense (from rooms view)",
 	"help.defense_row": "[l] lock · [c] CCTV · [w] wiring · [o] cooling · [a] armor",
 	"help.tip.idle":    "Tip: it's an incremental game — feel free to leave it running in tmux.",
@@ -170,12 +170,12 @@ var enStrings = map[string]string{
 
 	// Mercs.
 	"mercs.title":     "🐾 Mercenaries",
-	"mercs.help":      "[tab] switch tab   ↑/↓ select   [h] hire   [f] fire   [b] bribe (+15 loyalty, ₿200)   [esc]/[1] back",
+	"mercs.help":      "[tab] switch tab   ↑/↓ select   [h] hire   [f] fire   [b] bribe (+15 loyalty, %s)   [esc]/[1] back",
 	"mercs.yours":     "Your Mercs",
 	"mercs.empty":     "  (none — switch to Hire tab)",
 	"mercs.hire":      "Hire",
-	"mercs.owned_line": "room %s  wage ₿%d/wk  loyalty %d",
-	"mercs.hire_line":  "hire ₿%d",
+	"mercs.owned_line": "room %s  wage %s/wk  loyalty %d",
+	"mercs.hire_line":  "hire %s",
 	"mercs.defbonus":   "def +%.0f%%",
 	"mercs.loyalty":    "loyalty %d",
 
@@ -187,7 +187,7 @@ var enStrings = map[string]string{
 	"lab.active_none": "  (none)",
 	"lab.plan":        "Plan next research",
 	"lab.plan_tier":   "  Tier %d — %s",
-	"lab.plan_cost":   "  costs: ₿%d + %d frags  ·  duration: %dm",
+	"lab.plan_cost":   "  costs: %s + %d frags  ·  duration: %dm",
 	"lab.plan_boosts": "  boosts: %s + %s",
 	"lab.plan_hint":   "  (press [r] to start)",
 	"lab.bp_title":    "Blueprints (%d) — [p] to print selected",
@@ -198,7 +198,7 @@ var enStrings = map[string]string{
 	"prestige.locked":  "Prestige is locked. Unlock 'Venture Capital' in the Mogul skill lane.",
 	"prestige.help":    "[↑/↓] select perk   [p] buy perk   [R] RETIRE (press twice to confirm)   [esc]/[1] back",
 	"prestige.status":  "Status",
-	"prestige.lifetime": "  lifetime earned: ₿%.0f / ₿%.0f",
+	"prestige.lifetime": "  lifetime earned: %s / %s",
 	"prestige.eligible_yes": "ELIGIBLE",
 	"prestige.eligible_no":  "not eligible",
 	"prestige.eligible_row": "  retirement status: %s",
@@ -208,15 +208,15 @@ var enStrings = map[string]string{
 	"prestige.perk_owned": "owned / maxed",
 
 	// Small labels used across multiple views.
-	"label.eff":       "₿%.3f/s",
-	"label.bp_line":   "    eff %.4f ₿/s · %.0fV · %.0f°C · %.0fh durability",
+	"label.eff":       "%s/s",
+	"label.bp_line":   "    eff %s/s · %.0fV · %.0f°C · %.0fh durability",
 
 	// Event popup prompts.
 	"event.dismiss": "[press any key to dismiss]",
 
 	// Offline catch-up welcome-back notification.
 	"offline.title":   "😽 Welcome back!",
-	"offline.body":    "You were away for %s.\nEarned ₿%.4f while the rack kept humming.",
+	"offline.body":    "You were away for %s.\nEarned %s while the rack kept humming.",
 	"offline.capped":  "(capped at 8h — longer gaps stop accruing.)",
 	"offline.dismiss": "[press any key to dismiss]",
 
@@ -238,10 +238,10 @@ var enStrings = map[string]string{
 
 	"log.skill.learned": "\uf0eb Learned: %s.",
 
-	"log.merc.hired":              "\uf1b0 Hired %s for ₿%d.",
+	"log.merc.hired":              "\uf1b0 Hired %s for %s.",
 	"log.merc.dismissed":          "Dismissed %s. The other mercs noticed.",
 	"log.merc.bribed":             "\uf06b Bribed %s — loyalty now %d.",
-	"log.merc.wages":              "\uf0b1 Paid ₿%.2f in mercenary wages.",
+	"log.merc.wages":              "\uf0b1 Paid %s in mercenary wages.",
 	"log.merc.betray.unlock":      "\uf1b0 %s unlocked the door on the way out.",
 	"log.merc.betray.sabotage":    "\uf1e2 %s sabotaged something on the way out.",
 	"log.merc.betray.sold_story":  "\uf0a1 %s sold your story to a rival kitten. Rep −10.",
@@ -255,7 +255,7 @@ var enStrings = map[string]string{
 	"log.event.gift.sold":      "…but no room. Sold %s.",
 	"log.event.fire.averted":   "\uf132 Armor held. Nothing caught fire.",
 	"log.event.fire.warning":   "You've been warned. One more incident and the room is gone.",
-	"log.event.fire.money":     "\uf155 Lost ₿%.0f (%.0f%% of balance).",
+	"log.event.fire.money":     "\uf155 Lost %s (%.0f%% of balance).",
 	"log.event.fire.destroyed": "\uf06d Fire! %d GPUs destroyed in %s.",
 	"log.event.thief.empty":    "Thief found nothing worth taking. Huh.",
 	"log.event.thief.defended": "\uf132 Defense held. Nothing stolen.",
@@ -264,19 +264,19 @@ var enStrings = map[string]string{
 	"log.event.gpu.broken":     "\uf1e2 A GPU took too much damage — broken.",
 	"log.event.gpu.damaged":    "\uf071 A GPU is damaged.",
 	"log.event.repair.free":    "\uf0ad PCB surgery — free repair.",
-	"log.event.repair.paid":    "\uf0ad Repaired for ₿%d.",
+	"log.event.repair.paid":    "\uf0ad Repaired for %s.",
 
 	"log.gpu.arrived":         "\uf1b2 %s arrived and is online.",
 	"log.gpu.failed":          "\uf1e2 %s failed. It needs repair or scrapping.",
 	"log.gpu.upgrade.success": "\uf013 GPU upgraded to level %d.",
 	"log.gpu.upgrade.bricked": "\uf06d Upgrade failed — GPU is bricked.",
-	"log.gpu.ordered":         "Ordered %s for ₿%d. Tracking inbound…",
-	"log.gpu.scrapped":        "Scrapped %s for ₿%.0f + %d research fragments.",
+	"log.gpu.ordered":         "Ordered %s for %s. Tracking inbound…",
+	"log.gpu.scrapped":        "Scrapped %s for %s + %d research fragments.",
 
-	"log.bills.settled":  "\uf155 Bills settled: ₿%.2f electricity, ₿%.2f rent.",
+	"log.bills.settled":  "\uf155 Bills settled: %s electricity, %s rent.",
 	"log.bills.blackout": "\uf1e6 Couldn't pay the bill. Blackout for 60s.",
 
-	"log.room.vent":        "\uf2dc Emergency vent — heat reset, 30s power cycle, -₿%d.",
+	"log.room.vent":        "\uf2dc Emergency vent — heat reset, 30s power cycle, -%s.",
 	"log.room.moved":       "Moved into %s.",
 	"log.defense.upgraded": "\uf132 %s upgraded to level %d.",
 
@@ -289,7 +289,7 @@ var enStrings = map[string]string{
 	"log.pump.fired": "\uf201 Pump & Dump — BTC price ×1.5 for 5 minutes.",
 
 	"log.prestige.retired":  "\uf1b0 You retired rich. +%d LegacyPoints banked.",
-	"log.legacy.cash":       "Legacy bonus: +₿%.0f starter balance.",
+	"log.legacy.cash":       "Legacy bonus: +%s starter balance.",
 	"log.legacy.room":       "Legacy bonus: University Server Room pre-unlocked.",
 	"log.legacy.blueprints": "Legacy bonus: %d blueprints carried over.",
 	"hdr.achievements":    "🏆 %d/%d",

--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -208,7 +208,7 @@ var enStrings = map[string]string{
 	"prestige.perk_owned": "owned / maxed",
 
 	// Small labels used across multiple views.
-	"label.eff":       "eff %.4f ₿/s",
+	"label.eff":       "₿%.3f/s",
 	"label.bp_line":   "    eff %.4f ₿/s · %.0fV · %.0f°C · %.0fh durability",
 
 	// Event popup prompts.

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -208,7 +208,7 @@ var zhStrings = map[string]string{
 	"prestige.perk_owned":   "已拥有 / 满级",
 
 	// Small labels used across multiple views.
-	"label.eff":     "效率 %.4f ₿/秒",
+	"label.eff":     "₿%.3f/秒",
 	"label.bp_line": "    效率 %.4f ₿/秒 · %.0fV · %.0f°C · %.0fh 耐久",
 
 	// Event popup prompts.

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -38,9 +38,9 @@ var zhStrings = map[string]string{
 
 	// Dashboard.
 	"dash.location":   "📍 %s",
-	"dash.line.volt":  "⚡ %.0fV 耗电  ·  账单 −₿%.3f/秒  ·  下次结算 %d 秒",
+	"dash.line.volt":  "⚡ %.0fV 耗电  ·  账单 −%s/秒  ·  下次结算 %d 秒",
 	"dash.line.heat":  "🌡 %.0f°C / 最高 %.0f  ·  %+.1f°C 每 %d 秒  ·  下次 %d 秒",
-	"dash.line.cash":  "📈 收益 +₿%.3f/秒  ·  扣费后净 %+.3f/秒",
+	"dash.line.cash":  "📈 收益 +%s/秒  ·  扣费后净 %s/秒",
 	"dash.slots_of":   "槽位 %d/%d",
 	"dash.heat.warning":  "\uf071 温度过高 —— 效率减半 · 磨损 ×3",
 	"dash.heat.critical": "\uf06d 临界 —— 磨损 ×8 · 显卡即将烧毁",
@@ -51,8 +51,8 @@ var zhStrings = map[string]string{
 	"dash.power.safe":      "盈利中",
 	"dash.power.deficit":   "亏损中 —— 余额撑 %s",
 	"dash.power.broke":     "钱包见底 → 60 秒断电",
-	"dash.line.power":      "\uf0e7 %.0fV  −₿%.3f/秒  （下次账单 %d 秒）",
-	"dash.line.cash2":      "\uf201 +₿%.3f/秒 收益   净 %+.3f/秒",
+	"dash.line.power":      "\uf0e7 %.0fV  −%s/秒  （下次账单 %d 秒）",
+	"dash.line.cash2":      "\uf201 +%s/秒 收益   净 %s/秒",
 	"dash.heat.label":      "\uf2c7 温度  %.0f/%.0f°C  %+.1f/%d秒",
 	"dash.rack":           "显卡架",
 	"dash.empty_hint":     "  （空的——按 [2] 去商店）",
@@ -107,7 +107,7 @@ var zhStrings = map[string]string{
 	"rooms.help":       "↑/↓ 选房间   [u] 解锁   [enter] 切换   [l/c/w/o/a] 升级当前房间的防御   [esc]/[1] 返回",
 	"rooms.here":       "● 此处",
 	"rooms.unlocked":   "已解锁",
-	"rooms.to_unlock":  "解锁 ₿%d",
+	"rooms.to_unlock":  "解锁 %s",
 	"rooms.stats":      "  散热 %.1f · 电费 ×%.2f · 基础威胁 %.2f",
 	"rooms.defense":    "🛡  防御 —— 当前房间（%s）",
 	"rooms.dim.lock":    "门锁",
@@ -149,7 +149,7 @@ var zhStrings = map[string]string{
 	"help.g.pump":      "[p]      拉盘技能（主面板，需解锁）",
 	"help.g.lang":      "[L]      循环切换语言",
 	"help.g.quit":      "[q]      退出（自动存档）",
-	"help.g.vent":      "[V]      应急排热——重置房间温度 · -₿100 · 30 秒停机 · 2 分钟冷却",
+	"help.g.vent":      "[V]      应急排热——重置房间温度 · %s · 30 秒停机 · 2 分钟冷却",
 	"help.defense":     "房间防御（在房间视图里）",
 	"help.defense_row": "[l] 锁 · [c] 监控 · [w] 电路 · [o] 散热 · [a] 护甲",
 	"help.tip.idle":    "提示：这是增量器——放心开着 tmux 挂后台。",
@@ -170,12 +170,12 @@ var zhStrings = map[string]string{
 
 	// Mercs.
 	"mercs.title":      "🐾 佣兵",
-	"mercs.help":       "[tab] 切换标签   ↑/↓ 选择   [h] 雇佣   [f] 解雇   [b] 贿赂（忠诚 +15，₿200）   [esc]/[1] 返回",
+	"mercs.help":       "[tab] 切换标签   ↑/↓ 选择   [h] 雇佣   [f] 解雇   [b] 贿赂（忠诚 +15，%s）   [esc]/[1] 返回",
 	"mercs.yours":      "你的佣兵",
 	"mercs.empty":      "  （没有——切到雇佣标签）",
 	"mercs.hire":       "雇佣",
-	"mercs.owned_line": "房间 %s  周薪 ₿%d  忠诚 %d",
-	"mercs.hire_line":  "雇佣 ₿%d",
+	"mercs.owned_line": "房间 %s  周薪 %s  忠诚 %d",
+	"mercs.hire_line":  "雇佣 %s",
 	"mercs.defbonus":   "防御 +%.0f%%",
 	"mercs.loyalty":    "忠诚 %d",
 
@@ -187,7 +187,7 @@ var zhStrings = map[string]string{
 	"lab.active_none": "  （无）",
 	"lab.plan":        "下一次研究计划",
 	"lab.plan_tier":   "  档位 %d —— %s",
-	"lab.plan_cost":   "  消耗：₿%d + %d 碎片  ·  用时：%d 分钟",
+	"lab.plan_cost":   "  消耗：%s + %d 碎片  ·  用时：%d 分钟",
 	"lab.plan_boosts": "  加成：%s + %s",
 	"lab.plan_hint":   "  （按 [r] 开始研究）",
 	"lab.bp_title":    "蓝图（%d 个）—— 按 [p] 打印选中的",
@@ -198,7 +198,7 @@ var zhStrings = map[string]string{
 	"prestige.locked":       "转生未解锁。先去大亨技能里解锁「Venture Capital」。",
 	"prestige.help":         "[↑/↓] 选特权   [p] 购买   [R] 退休（按两次确认）   [esc]/[1] 返回",
 	"prestige.status":       "状态",
-	"prestige.lifetime":     "  累计收入：₿%.0f / ₿%.0f",
+	"prestige.lifetime":     "  累计收入：%s / %s",
 	"prestige.eligible_yes": "可以转生",
 	"prestige.eligible_no":  "暂时还不行",
 	"prestige.eligible_row": "  退休资格：%s",
@@ -208,15 +208,15 @@ var zhStrings = map[string]string{
 	"prestige.perk_owned":   "已拥有 / 满级",
 
 	// Small labels used across multiple views.
-	"label.eff":     "₿%.3f/秒",
-	"label.bp_line": "    效率 %.4f ₿/秒 · %.0fV · %.0f°C · %.0fh 耐久",
+	"label.eff":     "%s/秒",
+	"label.bp_line": "    效率 %s/秒 · %.0fV · %.0f°C · %.0fh 耐久",
 
 	// Event popup prompts.
 	"event.dismiss": "[按任意键关闭]",
 
 	// 离线收益欢迎回来提示。
 	"offline.title":   "😽 欢迎回来！",
-	"offline.body":    "你离开了 %s。\n矿机一直在嗡嗡作响，共赚了 ₿%.4f。",
+	"offline.body":    "你离开了 %s。\n矿机一直在嗡嗡作响，共赚了 %s。",
 	"offline.capped":  "（最多结算 8 小时，超过部分不计入）",
 	"offline.dismiss": "[按任意键关闭]",
 
@@ -237,10 +237,10 @@ var zhStrings = map[string]string{
 
 	"log.skill.learned": "\uf0eb 已学习：%s。",
 
-	"log.merc.hired":              "\uf1b0 雇佣 %s，花费 ₿%d。",
+	"log.merc.hired":              "\uf1b0 雇佣 %s，花费 %s。",
 	"log.merc.dismissed":          "已解雇 %s。其他佣兵注意到了。",
 	"log.merc.bribed":             "\uf06b 贿赂 %s —— 忠诚度 %d。",
-	"log.merc.wages":              "\uf0b1 支付了 ₿%.2f 佣兵工资。",
+	"log.merc.wages":              "\uf0b1 支付了 %s 佣兵工资。",
 	"log.merc.betray.unlock":      "\uf1b0 %s 离开时顺手把门解锁了。",
 	"log.merc.betray.sabotage":    "\uf1e2 %s 离开时破坏了些设备。",
 	"log.merc.betray.sold_story":  "\uf0a1 %s 把你的故事卖给了对家小猫。声望 −10。",
@@ -254,7 +254,7 @@ var zhStrings = map[string]string{
 	"log.event.gift.sold":      "……但是没地方放，直接卖掉了 %s。",
 	"log.event.fire.averted":   "\uf132 装甲挡住了，火情被压制。",
 	"log.event.fire.warning":   "已经警告过了。再来一次，这间房就没了。",
-	"log.event.fire.money":     "\uf155 损失 ₿%.0f（余额的 %.0f%%）。",
+	"log.event.fire.money":     "\uf155 损失 %s（余额的 %.0f%%）。",
 	"log.event.fire.destroyed": "\uf06d 失火！损失 %d 张显卡（%s）。",
 	"log.event.thief.empty":    "小偷没找到值钱的东西。",
 	"log.event.thief.defended": "\uf132 防御挡住了，没被偷走东西。",
@@ -263,19 +263,19 @@ var zhStrings = map[string]string{
 	"log.event.gpu.broken":     "\uf1e2 一张显卡承受了太多伤害 —— 彻底烧毁。",
 	"log.event.gpu.damaged":    "\uf071 一张显卡受损。",
 	"log.event.repair.free":    "\uf0ad PCB 手术 —— 免费修复。",
-	"log.event.repair.paid":    "\uf0ad 修复完成，花费 ₿%d。",
+	"log.event.repair.paid":    "\uf0ad 修复完成，花费 %s。",
 
 	"log.gpu.arrived":         "\uf1b2 %s 已抵达并上线。",
 	"log.gpu.failed":          "\uf1e2 %s 出故障了，需要维修或拆解。",
 	"log.gpu.upgrade.success": "\uf013 显卡升级到 %d 级。",
 	"log.gpu.upgrade.bricked": "\uf06d 升级失败 —— 显卡砖了。",
-	"log.gpu.ordered":         "下单 %s，₿%d。正在追踪物流……",
-	"log.gpu.scrapped":        "拆解 %s，获得 ₿%.0f 和 %d 研究碎片。",
+	"log.gpu.ordered":         "下单 %s，%s。正在追踪物流……",
+	"log.gpu.scrapped":        "拆解 %s，获得 %s 和 %d 研究碎片。",
 
-	"log.bills.settled":  "\uf155 账单结清：电费 ₿%.2f，房租 ₿%.2f。",
+	"log.bills.settled":  "\uf155 账单结清：电费 %s，房租 %s。",
 	"log.bills.blackout": "\uf1e6 付不起账单了。停电 60 秒。",
 
-	"log.room.vent":        "\uf2dc 紧急排热 —— 温度重置，断电 30 秒，花费 ₿%d。",
+	"log.room.vent":        "\uf2dc 紧急排热 —— 温度重置，断电 30 秒，花费 %s。",
 	"log.room.moved":       "搬进了 %s。",
 	"log.defense.upgraded": "\uf132 %s 升级到 %d 级。",
 
@@ -288,7 +288,7 @@ var zhStrings = map[string]string{
 	"log.pump.fired": "\uf201 拉盘砸盘 —— BTC 价格 ×1.5，持续 5 分钟。",
 
 	"log.prestige.retired":  "\uf1b0 你功成身退。+%d LegacyPoints 入账。",
-	"log.legacy.cash":       "Legacy 奖励：启动余额 +₿%.0f。",
+	"log.legacy.cash":       "Legacy 奖励：启动余额 +%s。",
 	"log.legacy.room":       "Legacy 奖励：大学机房已提前解锁。",
 	"log.legacy.blueprints": "Legacy 奖励：继承了 %d 份蓝图。",
 	"hdr.achievements":    "🏆 %d/%d",

--- a/ui/app.go
+++ b/ui/app.go
@@ -433,7 +433,7 @@ func (a App) renderHeader() string {
 	title := TitleStyle.Render(fmt.Sprintf("%s — %s", i18n.T("app.title"), a.state.KittenName)) + diffBadge
 
 	extras := []string{
-		BTCStyle.Render(formatBTC(a.state.BTC)),
+		BTCStyle.Render(game.FmtBTC(a.state.BTC)),
 		DimStyle.Render(i18n.T("hdr.tp", a.state.TechPoint)),
 		DimStyle.Render(i18n.T("hdr.rep", a.state.Reputation)),
 		DimStyle.Render(i18n.T("hdr.frags", a.state.ResearchFrags)),
@@ -518,8 +518,8 @@ func (a App) renderDifficultyPicker() string {
 		} else {
 			title = DimStyle.Render(title)
 		}
-		meta := DimStyle.Render(fmt.Sprintf("(earn ×%.2f · bills ×%.2f · threats ×%.2f · ₿%.0f start)",
-			d.EarnMult, d.BillMult, d.ThreatMult, d.StarterCash))
+		meta := DimStyle.Render(fmt.Sprintf("(earn ×%.2f · bills ×%.2f · threats ×%.2f · %s start)",
+			d.EarnMult, d.BillMult, d.ThreatMult, game.FmtBTC(d.StarterCash)))
 		lines = append(lines, cursor+title+"   "+meta)
 		lines = append(lines, DimStyle.Render("    "+d.LocalDesc()))
 		lines = append(lines, "")

--- a/ui/dashboard.go
+++ b/ui/dashboard.go
@@ -126,7 +126,7 @@ func (a App) notification() *notification {
 		s := a.showOfflineSummary
 		body := i18n.T("offline.body",
 			formatDuration(s.GapSeconds),
-			s.BTCGained)
+			game.FmtBTC(s.BTCGained))
 		if s.Capped {
 			body += "\n" + i18n.T("offline.capped")
 		}
@@ -276,12 +276,12 @@ func (a App) renderRoomPanel(def data.RoomDef, width int, compact bool) string {
 	}
 
 	lines = append(lines, fmt.Sprintf("%s   %s",
-		VoltStyle.Render(i18n.T("dash.line.power", volt, bill, nextBill)),
+		VoltStyle.Render(i18n.T("dash.line.power", volt, game.FmtBTC(bill), nextBill)),
 		DimStyle.Render(i18n.T("dash.slots_of", len(gpus), def.Slots))))
 	lines = append(lines, "  "+powerHint)
 	lines = append(lines, HeatStyle.Render(i18n.T("dash.heat.label", heat, maxHeat, heatDelta, heatTickSec)))
 	lines = append(lines, "  "+renderHeatBar(heatFrac, barW)+"  "+zoneStyle.Render(i18n.T(zoneLabel)))
-	lines = append(lines, netStyle.Render(i18n.T("dash.line.cash2", earn, net)))
+	lines = append(lines, netStyle.Render(i18n.T("dash.line.cash2", game.FmtBTC(earn), game.FmtBTCSigned(net))))
 	if !compact {
 		lines = append(lines, "")
 	}
@@ -408,8 +408,8 @@ func (a App) renderKeyInfoPanel(def data.RoomDef, width int, compact bool) strin
 	}
 	lines := []string{
 		TitleStyle.Render(truncate(i18n.T("dash.location", def.LocalName()), innerW)),
-		VoltStyle.Render(fmt.Sprintf("%s %.0fW  −₿%.2f/s", IconBolt, volt, bill)),
-		netStyle.Render(fmt.Sprintf("%s net %+.2f/s", IconChartUp, net)),
+		VoltStyle.Render(fmt.Sprintf("%s %.0fW  −%s/s", IconBolt, volt, game.FmtBTC(bill))),
+		netStyle.Render(fmt.Sprintf("%s net %s/s", IconChartUp, game.FmtBTCSigned(net))),
 		heatStyle.Render(fmt.Sprintf("%s %.0f/%.0f %+.1f/s", IconThermo, heat, maxHeat, heatDelta)),
 		renderHeatBar(heatFrac, barW),
 		impactStyle.Render(truncate(i18n.T(impactKey), innerW)),
@@ -674,7 +674,7 @@ func (a App) overlayOfflineSummary(content string) string {
 	}
 	body := i18n.T("offline.body",
 		formatDuration(s.GapSeconds),
-		s.BTCGained)
+		game.FmtBTC(s.BTCGained))
 	if s.Capped {
 		body += "\n" + i18n.T("offline.capped")
 	}

--- a/ui/gpus.go
+++ b/ui/gpus.go
@@ -56,7 +56,7 @@ func (a App) renderGPUsView() string {
 		rate := a.state.GPUEarnRatePerSec(g)
 		rateCell := ""
 		if rate > 0 {
-			rateCell = lipgloss.NewStyle().Foreground(OppGreen).Render(fmt.Sprintf("₿%.3f/s", rate))
+			rateCell = lipgloss.NewStyle().Foreground(OppGreen).Render(game.FmtBTC(rate) + "/s")
 		} else {
 			rateCell = DimStyle.Render("—")
 		}

--- a/ui/lab.go
+++ b/ui/lab.go
@@ -51,7 +51,7 @@ func (a App) renderLabView() string {
 	plan := []string{HeaderStyle.Render(i18n.T("lab.plan"))}
 	if curTier != nil {
 		plan = append(plan, i18n.T("lab.plan_tier", curTier.Tier, curTier.Name))
-		plan = append(plan, DimStyle.Render(i18n.T("lab.plan_cost", curTier.Money, curTier.Frags, curTier.Duration/60)))
+		plan = append(plan, DimStyle.Render(i18n.T("lab.plan_cost", game.FmtBTCInt(curTier.Money), curTier.Frags, curTier.Duration/60)))
 		plan = append(plan, i18n.T("lab.plan_boosts", combo[0], combo[1]))
 		plan = append(plan, DimStyle.Render(i18n.T("lab.plan_hint")))
 	}
@@ -68,7 +68,7 @@ func (a App) renderLabView() string {
 		eff, pow, heat, dur := game.BlueprintStats(bp)
 		bpLines = append(bpLines, fmt.Sprintf("%s[%s] tier %d  %s",
 			marker, bp.ID, bp.Tier, strings.Join(bp.Boosts, "+")))
-		bpLines = append(bpLines, DimStyle.Render(i18n.T("label.bp_line", eff, pow, heat, dur)))
+		bpLines = append(bpLines, DimStyle.Render(i18n.T("label.bp_line", game.FmtBTC(eff*game.MiningScale), pow, heat, dur)))
 	}
 
 	lw := fitWidth(90, a.w)

--- a/ui/log.go
+++ b/ui/log.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 )
 
@@ -47,7 +48,7 @@ func (a App) renderHelpView() string {
 		KeyHint.Render(i18n.T("help.g.save")),
 		KeyHint.Render(i18n.T("help.g.pump")),
 		KeyHint.Render(i18n.T("help.g.lang")),
-		KeyHint.Render(i18n.T("help.g.vent")),
+		KeyHint.Render(i18n.T("help.g.vent", "-"+game.FmtBTCInt(game.EmergencyVentCost))),
 		KeyHint.Render(i18n.T("help.g.quit")),
 		"",
 		HeaderStyle.Render(i18n.T("help.defense")),

--- a/ui/mercs.go
+++ b/ui/mercs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 )
 
@@ -16,7 +17,7 @@ func (a App) renderMercsView() string {
 	hireable := data.Mercs()
 
 	header := TitleStyle.Render(i18n.T("mercs.title"))
-	help := DimStyle.Render(i18n.T("mercs.help"))
+	help := DimStyle.Render(i18n.T("mercs.help", game.FmtBTCInt(200)))
 
 	ownedLines := []string{HeaderStyle.Render(i18n.T("mercs.yours"))}
 	if len(owned) == 0 {
@@ -44,7 +45,7 @@ func (a App) renderMercsView() string {
 		}
 		line := fmt.Sprintf("%s#%-3d %-28s  %s",
 			cursor, m.InstanceID, def.LocalName(),
-			loyStyle.Render(i18n.T("mercs.owned_line", roomName, def.WeeklyWage, m.Loyalty)),
+			loyStyle.Render(i18n.T("mercs.owned_line", roomName, game.FmtBTCInt(def.WeeklyWage), m.Loyalty)),
 		)
 		ownedLines = append(ownedLines, line)
 	}
@@ -59,10 +60,10 @@ func (a App) renderMercsView() string {
 		if a.state.BTC < float64(d.HireCost) {
 			priceStyle = DimStyle
 		}
-		line := fmt.Sprintf("%s%-24s  %s  wage ₿%d/wk  %s",
+		line := fmt.Sprintf("%s%-24s  %s  wage %s/wk  %s",
 			cursor, d.LocalName(),
-			priceStyle.Render(i18n.T("mercs.hire_line", d.HireCost)),
-			d.WeeklyWage, i18n.T("mercs.defbonus", d.DefenseBonus*100),
+			priceStyle.Render(i18n.T("mercs.hire_line", game.FmtBTCInt(d.HireCost))),
+			game.FmtBTCInt(d.WeeklyWage), i18n.T("mercs.defbonus", d.DefenseBonus*100),
 		)
 		hireLines = append(hireLines, line)
 		hireLines = append(hireLines, DimStyle.Render("   "+d.LocalFlavor()))

--- a/ui/prestige.go
+++ b/ui/prestige.go
@@ -24,7 +24,7 @@ func (a App) renderPrestigeView() string {
 	help := DimStyle.Render(i18n.T("prestige.help"))
 
 	lines := []string{HeaderStyle.Render(i18n.T("prestige.status"))}
-	lines = append(lines, i18n.T("prestige.lifetime", a.state.LifetimeEarned, game.PrestigeThreshold))
+	lines = append(lines, i18n.T("prestige.lifetime", game.FmtBTC(a.state.LifetimeEarned), game.FmtBTC(game.PrestigeThreshold)))
 	reward := a.state.RetireReward()
 	canRetire := a.state.CanRetire()
 	status := DimStyle.Render(i18n.T("prestige.eligible_no"))

--- a/ui/rooms.go
+++ b/ui/rooms.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 )
 
@@ -43,10 +44,10 @@ func (a App) renderRoomsView() string {
 		case unlocked:
 			state = DimStyle.Render(i18n.T("rooms.unlocked"))
 		default:
-			state = BTCStyle.Render(i18n.T("rooms.to_unlock", r.UnlockCost))
+			state = BTCStyle.Render(i18n.T("rooms.to_unlock", game.FmtBTCInt(r.UnlockCost)))
 		}
-		lines = append(lines, fmt.Sprintf("%s%-32s  %-10s  slots %-2d  rent ₿%d/h",
-			marker, r.LocalName(), state, r.Slots, r.RentPerHour,
+		lines = append(lines, fmt.Sprintf("%s%-32s  %-10s  slots %-2d  rent %s/h",
+			marker, r.LocalName(), state, r.Slots, game.FmtBTCInt(r.RentPerHour),
 		))
 	}
 
@@ -75,8 +76,8 @@ func (a App) renderRoomsView() string {
 			if lvl >= 5 {
 				style = lipgloss.NewStyle().Foreground(OppGreen)
 			}
-			lines = append(lines, style.Render(fmt.Sprintf("  [%s] %-8s  lv %d/5   next ₿%d",
-				d.Key, i18n.T(d.I18n), lvl, next)))
+			lines = append(lines, style.Render(fmt.Sprintf("  [%s] %-8s  lv %d/5   next %s",
+				d.Key, i18n.T(d.I18n), lvl, game.FmtBTCInt(next))))
 		}
 	}
 	return PanelStyle.Width(fitWidth(100, a.w)).Render(strings.Join(lines, "\n"))

--- a/ui/store.go
+++ b/ui/store.go
@@ -49,12 +49,12 @@ func (a App) renderStore() string {
 		if !affordable {
 			name = DimStyle.Render(name)
 		}
-		lines = append(lines, fmt.Sprintf("%s%-32s  %s  %s",
+		lines = append(lines, fmt.Sprintf("%s%-32s  %-9s  %s",
 			marker,
 			name,
-			priceStyle.Render(fmt.Sprintf("₿%-6d", g.Price)),
+			priceStyle.Render(game.FmtBTCInt(g.Price)),
 			DimStyle.Render(fmt.Sprintf("%s   %.0fV   %dh",
-				i18n.T("label.eff", g.Efficiency*game.MiningScale), g.PowerDraw, g.DurabilityHours)),
+				i18n.T("label.eff", game.FmtBTC(g.Efficiency*game.MiningScale)), g.PowerDraw, g.DurabilityHours)),
 		))
 	}
 

--- a/ui/store.go
+++ b/ui/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/game"
 	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
 )
 
@@ -53,7 +54,7 @@ func (a App) renderStore() string {
 			name,
 			priceStyle.Render(fmt.Sprintf("₿%-6d", g.Price)),
 			DimStyle.Render(fmt.Sprintf("%s   %.0fV   %dh",
-				i18n.T("label.eff", g.Efficiency), g.PowerDraw, g.DurabilityHours)),
+				i18n.T("label.eff", g.Efficiency*game.MiningScale), g.PowerDraw, g.DurabilityHours)),
 		))
 	}
 

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -53,23 +52,6 @@ var (
 // fitWidth clamps an ideal panel width to what the terminal can actually
 // show, with a sensible floor so we don't collapse past readability.
 // `availW` should be the current terminal width (App.w).
-// formatBTC renders a balance with adaptive precision: 3 decimals under
-// ₿10 (so ticks at 0.3/s feel alive early game), 2 under ₿1K, 1 under
-// ₿100K, 0 above. Keeps the header from getting ugly at late-game scale
-// while preserving the "dribble upward" feel at the start.
-func formatBTC(v float64) string {
-	switch {
-	case v < 10:
-		return fmt.Sprintf("₿%.3f", v)
-	case v < 1000:
-		return fmt.Sprintf("₿%.2f", v)
-	case v < 100000:
-		return fmt.Sprintf("₿%.1f", v)
-	default:
-		return fmt.Sprintf("₿%.0f", v)
-	}
-}
-
 func fitWidth(ideal, availW int) int {
 	max := availW - 2 // outer padding around panels
 	if max < 30 {


### PR DESCRIPTION
## Summary
- Displayed BTC values now divide by `game.DisplayScale = 300` at render time. A GTX 1060 reads ~₿0.4 instead of ~₿120, and early-game tick rates like ₿0.0012/s finally look like crypto.
- Internal math, JSON prices, `MiningScale=300`, and saves are untouched — this is a UI-only change. Existing save files will open with the same balances, just shown on the new scale.
- Three shared formatters live in `core/game/btcfmt.go` (`FmtBTC`, `FmtBTCInt`, `FmtBTCSigned`) so future render sites don't reinvent adaptive precision. i18n templates switched from hardcoded `₿%d`/`₿%.3f` to `%s` placeholders with call sites pre-formatting.
- Removed duplicate `formatBTC` helper in `ui/styles.go`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (core/game, core/data, core/i18n)
- [ ] Launch, confirm header balance, dashboard power/cash lines, store prices, GPU earn rates, mercs/lab/rooms/prestige screens all render BTC values through the new scale.
- [ ] Load an existing save — balance should match the old raw value divided by 300.