### PR TITLE
Mastery ladder + frag→BTC alchemy — late-game TP/frag ceiling

### DIFF
--- a/core/data/mastery.go
+++ b/core/data/mastery.go
@@ -1,0 +1,84 @@
+package data
+
+import "github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
+
+// MasteryTrack is one infinite-ladder TP sink. Unlike the bounded skill
+// tree, mastery levels can keep climbing — costs ramp linearly, effect
+// stacks multiplicatively. The point is to absorb late-game TP overflow
+// and give players a "numbers go up" goal that survives every prestige.
+type MasteryTrack struct {
+	ID       string
+	Name     string
+	NameZH   string
+	Desc     string
+	DescZH   string
+	Emoji    string
+	Effect   string  // "mining" | "power" | "cooling" | "frags"
+	PerLevel float64 // multiplicative factor applied per level
+	BaseCost int     // first level's TP cost; total cost = base + level*step
+	StepCost int
+	MaxLevel int
+}
+
+func (t MasteryTrack) LocalName() string { return i18n.Pick(t.Name, t.NameZH) }
+func (t MasteryTrack) LocalDesc() string { return i18n.Pick(t.Desc, t.DescZH) }
+
+// CostFor returns the TP cost to advance FROM `currentLevel` to currentLevel+1.
+// Cost ramps linearly so early gains are cheap and 50→51 is a real commitment.
+func (t MasteryTrack) CostFor(currentLevel int) int {
+	if currentLevel >= t.MaxLevel {
+		return -1
+	}
+	return t.BaseCost + currentLevel*t.StepCost
+}
+
+var masteryTracks = []MasteryTrack{
+	{
+		ID: "mining", Emoji: "⛏",
+		Name: "Mining Mastery", NameZH: "挖矿精通",
+		Desc:   "+1% earn rate per level, multiplicative.",
+		DescZH: "每级 +1% 产出（乘法叠加）。",
+		Effect: "mining", PerLevel: 0.01, BaseCost: 3, StepCost: 2, MaxLevel: 50,
+	},
+	{
+		ID: "power", Emoji: "⚡",
+		Name: "Power Engineering", NameZH: "电力工程",
+		Desc:   "−1% electricity bills per level, multiplicative.",
+		DescZH: "每级 −1% 电费（乘法叠加）。",
+		Effect: "power", PerLevel: -0.01, BaseCost: 3, StepCost: 2, MaxLevel: 50,
+	},
+	{
+		ID: "cooling", Emoji: "❄",
+		Name: "Thermal Mastery", NameZH: "散热精通",
+		Desc:   "+2% room cooling per level, multiplicative.",
+		DescZH: "每级 +2% 房间散热（乘法叠加）。",
+		Effect: "cooling", PerLevel: 0.02, BaseCost: 4, StepCost: 2, MaxLevel: 50,
+	},
+	{
+		ID: "frags", Emoji: "🔬",
+		Name: "Fragment Mastery", NameZH: "碎片精通",
+		Desc:   "+2% research fragments from scrapping per level.",
+		DescZH: "每级拆解 +2% 碎片产出。",
+		Effect: "frags", PerLevel: 0.02, BaseCost: 4, StepCost: 2, MaxLevel: 50,
+	},
+	{
+		ID: "scrap", Emoji: "♻",
+		Name: "Salvage Mastery", NameZH: "拆解精通",
+		Desc:   "+1.5% scrap value per level.",
+		DescZH: "每级 +1.5% 拆解售价。",
+		Effect: "scrap", PerLevel: 0.015, BaseCost: 3, StepCost: 2, MaxLevel: 50,
+	},
+}
+
+// MasteryTracks returns the catalog (read-only — mutating the slice is UB).
+func MasteryTracks() []MasteryTrack { return masteryTracks }
+
+// MasteryByID returns the track or false if unknown.
+func MasteryByID(id string) (MasteryTrack, bool) {
+	for _, t := range masteryTracks {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return MasteryTrack{}, false
+}

--- a/core/game/mastery.go
+++ b/core/game/mastery.go
@@ -1,0 +1,105 @@
+package game
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
+)
+
+// LevelUpMastery advances the named mastery track by one level. Returns the
+// new level on success, or an error describing why the purchase failed.
+func (s *State) LevelUpMastery(id string) (int, error) {
+	track, ok := data.MasteryByID(id)
+	if !ok {
+		return 0, fmt.Errorf("no such mastery track")
+	}
+	if s.MasteryLevels == nil {
+		s.MasteryLevels = map[string]int{}
+	}
+	cur := s.MasteryLevels[id]
+	if cur >= track.MaxLevel {
+		return cur, fmt.Errorf("mastery already at max")
+	}
+	cost := track.CostFor(cur)
+	if cost < 0 {
+		return cur, fmt.Errorf("mastery already at max")
+	}
+	if s.TechPoint < cost {
+		return cur, fmt.Errorf("need %d TP, have %d", cost, s.TechPoint)
+	}
+	s.TechPoint -= cost
+	s.MasteryLevels[id] = cur + 1
+	s.appendLog("opportunity",
+		i18n.T("log.mastery.leveled", track.LocalName(), cur+1))
+	return cur + 1, nil
+}
+
+// MasteryLevel returns the current level of a track (0 if untouched).
+func (s *State) MasteryLevel(id string) int {
+	if s.MasteryLevels == nil {
+		return 0
+	}
+	return s.MasteryLevels[id]
+}
+
+// masteryMult returns (1+per_level)^level for the given track effect — the
+// multiplicative bonus that level N grants. Called by the per-effect
+// helpers below.
+func (s *State) masteryMult(effect string) float64 {
+	mult := 1.0
+	for _, t := range data.MasteryTracks() {
+		if t.Effect != effect {
+			continue
+		}
+		lvl := s.MasteryLevel(t.ID)
+		if lvl <= 0 {
+			continue
+		}
+		mult *= math.Pow(1.0+t.PerLevel, float64(lvl))
+	}
+	return mult
+}
+
+// MasteryEarnMult is the mining-mastery multiplier applied to BTC earn rate.
+func (s *State) MasteryEarnMult() float64 { return s.masteryMult("mining") }
+
+// MasteryBillMult is the power-engineering multiplier applied to bills.
+// Note: PerLevel is negative for "power" so the math returns < 1.0 when
+// levels are unlocked (the player's bills shrink).
+func (s *State) MasteryBillMult() float64 { return s.masteryMult("power") }
+
+// MasteryCoolingMult multiplies the room's passive cooling rate.
+func (s *State) MasteryCoolingMult() float64 { return s.masteryMult("cooling") }
+
+// MasteryFragMult scales fragments earned when scrapping a GPU.
+func (s *State) MasteryFragMult() float64 { return s.masteryMult("frags") }
+
+// MasteryScrapMult stacks with skill-based scrap multipliers on sell value.
+func (s *State) MasteryScrapMult() float64 { return s.masteryMult("scrap") }
+
+// ConvertFragsToBTC is the lab-side alchemy: trade research fragments for
+// raw BTC at a lossy rate. Provides a sink when frags pile up faster than
+// research can absorb them. Requires R&D to be unlocked.
+//
+//	frags is the count to spend; rate is the per-frag BTC payout.
+//
+// Returns the BTC credited or an error.
+func (s *State) ConvertFragsToBTC(frags int) (float64, error) {
+	if !s.HasUnlock("rd") {
+		return 0, fmt.Errorf("requires R&D unlock")
+	}
+	if frags <= 0 {
+		return 0, fmt.Errorf("frags must be positive")
+	}
+	if s.ResearchFrags < frags {
+		return 0, fmt.Errorf("need %d frags, have %d", frags, s.ResearchFrags)
+	}
+	const ratePerFrag = 0.5 // 1 frag → ₿0.5; tune if frags overflow worse
+	gained := float64(frags) * ratePerFrag
+	s.ResearchFrags -= frags
+	s.BTC += gained
+	s.appendLog("info", i18n.T("log.alchemy.frags", frags, FmtBTC(gained)))
+	return gained, nil
+}

--- a/core/game/mastery_test.go
+++ b/core/game/mastery_test.go
@@ -1,0 +1,111 @@
+package game
+
+import (
+	"math"
+	"testing"
+)
+
+// TestLevelUpMasteryDeductsTP verifies the basic TP-pay-and-advance loop.
+func TestLevelUpMasteryDeductsTP(t *testing.T) {
+	withTempHome(t)
+	s := NewState("Mastery")
+	s.TechPoint = 100
+
+	beforeTP := s.TechPoint
+	lvl, err := s.LevelUpMastery("mining")
+	if err != nil {
+		t.Fatalf("LevelUpMastery: %v", err)
+	}
+	if lvl != 1 {
+		t.Errorf("expected level 1 after first up, got %d", lvl)
+	}
+	if s.TechPoint >= beforeTP {
+		t.Error("TP should have been deducted")
+	}
+	if s.MasteryLevel("mining") != 1 {
+		t.Errorf("MasteryLevel mismatch: %d", s.MasteryLevel("mining"))
+	}
+}
+
+// TestMasteryMultStacks verifies multiplicative compounding.
+func TestMasteryMultStacks(t *testing.T) {
+	withTempHome(t)
+	s := NewState("Stack")
+	s.TechPoint = 10000
+	for i := 0; i < 10; i++ {
+		if _, err := s.LevelUpMastery("mining"); err != nil {
+			t.Fatalf("level %d: %v", i+1, err)
+		}
+	}
+	got := s.MasteryEarnMult()
+	want := math.Pow(1.01, 10)
+	if math.Abs(got-want) > 0.0001 {
+		t.Errorf("expected %.4f, got %.4f", want, got)
+	}
+}
+
+// TestPowerMasteryReducesBills verifies the negative-PerLevel track shrinks
+// the multiplier (bills go down, not up).
+func TestPowerMasteryReducesBills(t *testing.T) {
+	withTempHome(t)
+	s := NewState("Power")
+	s.TechPoint = 5000
+	for i := 0; i < 20; i++ {
+		if _, err := s.LevelUpMastery("power"); err != nil {
+			t.Fatalf("level %d: %v", i+1, err)
+		}
+	}
+	got := s.MasteryBillMult()
+	if got >= 1.0 {
+		t.Errorf("expected discount < 1.0, got %.4f", got)
+	}
+}
+
+// TestConvertFragsRequiresRD ensures the alchemy gate fires correctly.
+func TestConvertFragsRequiresRD(t *testing.T) {
+	withTempHome(t)
+	s := NewState("Alchemy")
+	s.ResearchFrags = 50
+
+	if _, err := s.ConvertFragsToBTC(10); err == nil {
+		t.Error("expected error without R&D unlocked")
+	}
+
+	// Walk the engineer chain to unlock rd.
+	s.TechPoint = 100
+	_ = s.UnlockSkill("undervolt_i")
+	_ = s.UnlockSkill("undervolt_ii")
+	_ = s.UnlockSkill("rd_unlock")
+	if !s.HasUnlock("rd") {
+		t.Fatal("rd unlock should be set after walking the prereq chain")
+	}
+
+	beforeBTC := s.BTC
+	got, err := s.ConvertFragsToBTC(10)
+	if err != nil {
+		t.Fatalf("ConvertFragsToBTC: %v", err)
+	}
+	if got <= 0 {
+		t.Errorf("expected positive BTC, got %.4f", got)
+	}
+	if s.BTC <= beforeBTC {
+		t.Error("BTC should have increased")
+	}
+	if s.ResearchFrags != 40 {
+		t.Errorf("expected 40 frags after spend, got %d", s.ResearchFrags)
+	}
+}
+
+// TestConvertFragsRejectsOverdraft prevents spending more frags than held.
+func TestConvertFragsRejectsOverdraft(t *testing.T) {
+	withTempHome(t)
+	s := NewState("Bust")
+	s.TechPoint = 100
+	_ = s.UnlockSkill("undervolt_i")
+	_ = s.UnlockSkill("undervolt_ii")
+	_ = s.UnlockSkill("rd_unlock")
+	s.ResearchFrags = 5
+	if _, err := s.ConvertFragsToBTC(10); err == nil {
+		t.Error("expected error when spending more frags than held")
+	}
+}

--- a/core/game/state.go
+++ b/core/game/state.go
@@ -158,6 +158,11 @@ type State struct {
 	// at end of tick by CheckAchievements().
 	Achievements []string `json:"achievements,omitempty"`
 
+	// MasteryLevels tracks the per-track count of mastery levels unlocked.
+	// Late-game TP sink — see core/data/mastery.go for tracks. Multipliers
+	// stack multiplicatively via MasteryEarnMult / MasteryBillMult / etc.
+	MasteryLevels map[string]int `json:"mastery_levels,omitempty"`
+
 	// Lifetime counters powering the Stats view ([0]). Incremented in their
 	// respective systems (Tick, addGPU, SellGPU, payWages, applyEvent,
 	// advanceMarket). MarketPriceHistory is bounded to MarketHistoryCap
@@ -394,9 +399,13 @@ func (s *State) SellGPU(instanceID int) error {
 				base = def.ScrapValue
 				name = def.LocalName()
 			}
-			value := float64(base) * s.ScrapValueMult()
-			// Also grant 1-3 research fragments.
-			frags := 1 + rand.Intn(3)
+			value := float64(base) * s.ScrapValueMult() * s.MasteryScrapMult()
+			// Also grant 1-3 research fragments. Mastery scales the yield.
+			rawFrags := 1 + rand.Intn(3)
+			frags := int(float64(rawFrags) * s.MasteryFragMult())
+			if frags < rawFrags {
+				frags = rawFrags
+			}
 			s.BTC += value
 			s.ResearchFrags += frags
 			s.GPUs = append(s.GPUs[:i], s.GPUs[i+1:]...)

--- a/core/game/tick.go
+++ b/core/game/tick.go
@@ -158,7 +158,7 @@ func (s *State) advanceMining(now int64, dt float64) {
 		if !ok {
 			continue
 		}
-		coolingBonus := 1.0 + 0.25*float64(room.CoolingLvl)
+		coolingBonus := (1.0 + 0.25*float64(room.CoolingLvl)) * s.MasteryCoolingMult()
 
 		for _, g := range s.GPUs {
 			if g.Room != roomID || g.Status != "running" {
@@ -170,7 +170,7 @@ func (s *State) advanceMining(now int64, dt float64) {
 				efficiencyFactor = 0.5
 			}
 			if !miningPaused {
-				earned := eff * dt * earnMult * efficiencyFactor * s.DifficultyEarnMult() * s.MarketPrice * MiningScale
+				earned := eff * dt * earnMult * efficiencyFactor * s.DifficultyEarnMult() * s.MarketPrice * MiningScale * s.MasteryEarnMult()
 				// Syndicate cut: divert the agreed fraction into the
 				// contribution pool before crediting BTC so the player
 				// only sees (1-cut) of each GPU's raw earn. Proportional
@@ -258,7 +258,7 @@ func (s *State) advanceBilling(now int64) {
 	minutes := float64(now-s.LastBillUnix) / 60.0
 	s.LastBillUnix = now
 
-	billMult := s.BillMult() * s.DifficultyBillMult()
+	billMult := s.BillMult() * s.DifficultyBillMult() * s.MasteryBillMult()
 	totalBill := 0.0
 	totalRent := 0.0
 	for roomID := range s.Rooms {

--- a/core/i18n/en.go
+++ b/core/i18n/en.go
@@ -18,6 +18,25 @@ var enStrings = map[string]string{
 	"nav.lab":         "lab",
 	"nav.prestige":    "prestige",
 	"nav.stats":       "stats",
+	"nav.mastery":     "mastery",
+
+	// Mastery view.
+	"mastery.title":         "🌟 Mastery",
+	"mastery.help":           "↑/↓ select   [u]/[enter] level up   [esc]/[1] back",
+	"mastery.next_cost":      "next +1 = %d TP",
+	"mastery.maxed":          "MAX",
+	"mastery.alchemy_note":   "  Tip: in [8] Lab press [x] to convert 10 frags → ₿ (lossy).",
+
+	// Status.
+	"status.mastery_up":      "🌟 %s leveled up",
+	"status.alchemy":         "🔬 converted %d frags → %s",
+
+	// Alchemy.
+	"alchemy.no_frags":       "no frags to convert",
+
+	// Logs.
+	"log.mastery.leveled":    "🌟 %s reached level %d.",
+	"log.alchemy.frags":      "🔬 Alchemy: %d frags → %s.",
 
 	"hdr.tp":    "TP %d",
 	"hdr.rep":   "Rep %+d",
@@ -188,7 +207,8 @@ var enStrings = map[string]string{
 	"hint.rooms":     "[u] unlock  [enter] switch  [l/c/w/o/a] defense",
 	"hint.skills":    "[u] unlock  [esc] back",
 	"hint.mercs":     "[tab] switch  [h] hire  [f] fire  [b] bribe",
-	"hint.lab":       "[t] tier  [b] boosts  [r] research  [p] print",
+	"hint.lab":       "[t] tier  [b] boosts  [r] research  [p] print  [x] frag→₿",
+	"hint.mastery":   "↑/↓ select  [u] level up  [esc] back",
 	"hint.prestige":  "[p] perk  [R R] retire  [y]/[n] syndicate",
 	"hint.stats":     "[esc] back",
 

--- a/core/i18n/zh.go
+++ b/core/i18n/zh.go
@@ -18,6 +18,25 @@ var zhStrings = map[string]string{
 	"nav.lab":         "实验室",
 	"nav.prestige":    "转生",
 	"nav.stats":       "统计",
+	"nav.mastery":     "精通",
+
+	// Mastery view.
+	"mastery.title":          "🌟 精通",
+	"mastery.help":           "↑/↓ 选择   [u]/[enter] 升级   [esc]/[1] 返回",
+	"mastery.next_cost":      "下一级 = %d TP",
+	"mastery.maxed":          "已满级",
+	"mastery.alchemy_note":   "  提示：在 [8] 实验室按 [x] 把 10 碎片换成 ₿（有损耗）。",
+
+	// Status.
+	"status.mastery_up":      "🌟 %s 升级了",
+	"status.alchemy":         "🔬 兑换 %d 碎片 → %s",
+
+	// Alchemy.
+	"alchemy.no_frags":       "没有碎片可兑换",
+
+	// Logs.
+	"log.mastery.leveled":    "🌟 %s 到达 %d 级。",
+	"log.alchemy.frags":      "🔬 炼金：%d 碎片 → %s。",
 
 	"hdr.tp":    "TP %d",
 	"hdr.rep":   "声望 %+d",
@@ -187,7 +206,8 @@ var zhStrings = map[string]string{
 	"hint.rooms":     "[u] 解锁  [enter] 切换  [l/c/w/o/a] 防御",
 	"hint.skills":    "[u] 解锁  [esc] 返回",
 	"hint.mercs":     "[tab] 切换  [h] 雇佣  [f] 解雇  [b] 贿赂",
-	"hint.lab":       "[t] 档位  [b] 加成  [r] 研究  [p] 打印",
+	"hint.lab":       "[t] 档位  [b] 加成  [r] 研究  [p] 打印  [x] 碎片→₿",
+	"hint.mastery":   "↑/↓ 选择  [u] 升级  [esc] 返回",
 	"hint.prestige":  "[p] 特权  [R R] 退休  [y]/[n] 加盟/退盟",
 	"hint.stats":     "[esc] 返回",
 

--- a/ui/app.go
+++ b/ui/app.go
@@ -26,6 +26,7 @@ const (
 	viewLab
 	viewPrestige
 	viewStats
+	viewMastery
 	viewHelp
 )
 
@@ -70,6 +71,7 @@ type App struct {
 	labBoost2      int // reserved
 	labTier        int // 1..3
 	prestigeCursor int
+	masteryCursor  int
 
 	// Splash overlay phases — name first, then difficulty. Sim is frozen
 	// while a splash phase is active so the starter GPU doesn't tick down.
@@ -308,6 +310,9 @@ func (a App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		a.view = viewHelp
 		return a, nil
+	case "m":
+		a.view = viewMastery
+		return a, nil
 	case " ":
 		a.state.TogglePause()
 		return a, nil
@@ -347,6 +352,8 @@ func (a App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a.handleLabKey(key)
 	case viewPrestige:
 		return a.handlePrestigeKey(key)
+	case viewMastery:
+		return a.handleMasteryKey(key)
 	}
 
 	// Dashboard-only fallbacks.
@@ -414,6 +421,8 @@ func (a App) View() string {
 		body = a.renderPrestigeView()
 	case viewStats:
 		body = a.renderStatsView()
+	case viewMastery:
+		body = a.renderMasteryView()
 	case viewHelp:
 		body = a.renderHelpView()
 	}

--- a/ui/hint.go
+++ b/ui/hint.go
@@ -23,6 +23,8 @@ func (a App) renderViewHint() string {
 		key = "hint.prestige"
 	case viewStats:
 		key = "hint.stats"
+	case viewMastery:
+		key = "hint.mastery"
 	default:
 		return ""
 	}

--- a/ui/lab.go
+++ b/ui/lab.go
@@ -112,6 +112,20 @@ func (a App) handleLabKey(key string) (tea.Model, tea.Cmd) {
 				a = a.withStatus(i18n.T("status.printed"))
 			}
 		}
+	case "x":
+		// Frag → BTC alchemy. Trade 10 frags at a time at the lossy rate
+		// from State.ConvertFragsToBTC. Bounded to whatever the player has.
+		batch := 10
+		if a.state.ResearchFrags < batch {
+			batch = a.state.ResearchFrags
+		}
+		if batch <= 0 {
+			a = a.withStatus(i18n.T("status.error_prefix") + i18n.T("alchemy.no_frags"))
+		} else if got, err := a.state.ConvertFragsToBTC(batch); err != nil {
+			a = a.withStatus(i18n.T("status.error_prefix") + err.Error())
+		} else {
+			a = a.withStatus(i18n.T("status.alchemy", batch, game.FmtBTC(got)))
+		}
 	case "esc":
 		a.view = viewDashboard
 	}

--- a/ui/mastery.go
+++ b/ui/mastery.go
@@ -1,0 +1,89 @@
+package ui
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/data"
+	"github.com/RandomNameORG/kitten-crypto-mining-ventures/core/i18n"
+)
+
+// renderMasteryView shows the mastery ladder — infinite-ish TP sinks with
+// multiplicative bonuses. Shows current level, next-level cost, and the
+// effective multiplier so the player can plan TP spending.
+func (a App) renderMasteryView() string {
+	tracks := data.MasteryTracks()
+	header := TitleStyle.Render(i18n.T("mastery.title")) +
+		"   " + DimStyle.Render(i18n.T("skills.tp_count", a.state.TechPoint))
+	help := DimStyle.Render(i18n.T("mastery.help"))
+
+	lines := []string{header, help, ""}
+
+	for i, t := range tracks {
+		cur := a.state.MasteryLevel(t.ID)
+		cost := t.CostFor(cur)
+		mult := math.Pow(1.0+t.PerLevel, float64(cur))
+
+		cursor := "  "
+		if i == a.masteryCursor {
+			cursor = TitleStyle.Render("▶ ")
+		}
+
+		nameLine := cursor + lipgloss.NewStyle().Foreground(KittenPink).Bold(true).
+			Render(fmt.Sprintf("%s  %s", t.Emoji, t.LocalName()))
+		nameLine += "   " + DimStyle.Render(fmt.Sprintf("Lv %d / %d", cur, t.MaxLevel))
+
+		// Show current effective multiplier; for power that's < 1.0 (a discount).
+		var multStr string
+		if t.PerLevel < 0 {
+			multStr = fmt.Sprintf("%.0f%%", mult*100)
+		} else {
+			multStr = fmt.Sprintf("×%.3f", mult)
+		}
+
+		costStr := i18n.T("mastery.maxed")
+		if cost > 0 {
+			costStr = i18n.T("mastery.next_cost", cost)
+		}
+
+		statLine := DimStyle.Render(fmt.Sprintf("    %s   ·   now %s   ·   %s",
+			t.LocalDesc(), multStr, costStr))
+
+		lines = append(lines, nameLine, statLine, "")
+	}
+
+	lines = append(lines,
+		DimStyle.Render(i18n.T("mastery.alchemy_note")))
+
+	return PanelStyle.Width(fitWidth(90, a.w)).Render(strings.Join(lines, "\n"))
+}
+
+func (a App) handleMasteryKey(key string) (tea.Model, tea.Cmd) {
+	tracks := data.MasteryTracks()
+	switch key {
+	case "up", "k":
+		if a.masteryCursor > 0 {
+			a.masteryCursor--
+		}
+	case "down", "j":
+		if a.masteryCursor < len(tracks)-1 {
+			a.masteryCursor++
+		}
+	case "u", "enter":
+		if a.masteryCursor < len(tracks) {
+			t := tracks[a.masteryCursor]
+			if _, err := a.state.LevelUpMastery(t.ID); err != nil {
+				a = a.withStatus(i18n.T("status.error_prefix") + err.Error())
+			} else {
+				a = a.withStatus(i18n.T("status.mastery_up", t.LocalName()))
+			}
+		}
+	case "esc":
+		a.view = viewDashboard
+	}
+	return a, nil
+}


### PR DESCRIPTION
## Summary

Player feedback: TP and fragments stack up faster than the existing systems can spend them. Skill tree caps out around 60 TP, lab swallows frags but only when actively researching. This PR adds two late-game sinks that scale with playtime:

### 1. Mastery ladder (the headline TP sink)

5 mastery tracks, each with 50 multiplicative levels:

| Track | Per-level | Max (L50) | Notes |
|---|---|---|---|
| ⛏ Mining | ×1.01 earn | ×1.64 | feeds advanceMining |
| ⚡ Power | ×0.99 bills | ≈0.61 | feeds advanceBilling |
| ❄ Cooling | ×1.02 cooling | ×2.69 | scales room base_cooling |
| 🔬 Frags | ×1.02 frag yield | ×2.69 | scales scrap drops |
| ♻ Salvage | ×1.015 scrap $ | ×2.11 | scales sell price |

Cost ramps linearly: \`3 + level*2\` TP per step (or \`4 + level*2\` for cooling/frags). Total per track ~2700 TP at full → ~14k TP across all tracks. Multiplicatively compounded so the curve stays fun even as multipliers stack.

New view at \`[m]\` Mastery — same render style as the existing skill tree, but each track shows the current level, current effective multiplier, and next-level TP cost. \`[u]\` or \`[enter]\` to level up the highlighted track.

### 2. Frag → BTC alchemy (small frag sink)

\`State.ConvertFragsToBTC(n)\` — gated behind R&D unlock, lossy at 0.5 ₿/frag. Pressing \`[x]\` in the lab converts 10 frags at a time. Quick exhaust valve for when frags overflow but you don't want to research yet.

## What's wired

- \`State.MasteryLevels\` persists per-save
- Mastery multipliers thread through \`advanceMining\` / \`advanceBilling\` / cooling computation / SellGPU frag drop / scrap value
- New i18n cluster (\`mastery.*\`, \`alchemy.*\`) in EN + ZH
- Hint line for the new view

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 ./...\` all green (5 new mastery/alchemy tests)
- [ ] (reviewer) Open \`[m]\` Mastery, level up Mining a few times, watch dashboard earn rate climb
- [ ] (reviewer) Walk the engineer prereq chain to RD unlock, hit \`[x]\` in lab, see BTC bump and frags drop by 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)