### PR TITLE
feat(web/api): align snapshot + actions with GAME_DESIGN.md v2.1

### DIFF
--- a/docs/plans/web-api-audit.md
+++ b/docs/plans/web-api-audit.md
@@ -180,6 +180,44 @@ Group all the lifetime counters that today live unexposed on `*State`:
 | `EventsByCategory` — `state.go:183`                            | `events_by_category`                            |
 | `MarketPriceHistory` — `state.go:185` (cap `MarketHistoryCap`) | `market_price_history`                          |
 
+### 2.12 Sprint 2 — design catalogs and small enrichments
+
+Added in Sprint 2 so the frontend can render Achievement / Mastery / Legacy
+panels without hardcoding the catalog. All additive — existing keys (`achievements`,
+`mastery_levels`) are unchanged.
+
+- **`achievement_defs: []achievementDefView`** — full catalog from
+  `data.Achievements()`. Per entry: `id`, `emoji`, `name` (`def.LocalName()`),
+  `desc` (`def.LocalDesc()`), `tp_reward`, `earned` (`s.HasAchievement(id)`).
+- **`mastery_tracks: []masteryTrackView`** — full catalog from
+  `data.MasteryTracks()` joined with the player's per-track level. Per entry:
+  `id`, `emoji`, `name`, `desc`, `effect`, `per_level`, `level`
+  (`s.MasteryLevel(t.ID)`), `max_level`, `next_cost` (`t.CostFor(level)` —
+  `-1` sentinel when maxed, kept as-is per engine contract), `maxed`.
+- **`legacy_perks: []legacyPerkView`** — `game.LegacyPerks()` joined with the
+  loaded `*LegacyStore`. Per entry: `id`, `name`, `desc`, `cost`, `available`
+  (`p.Available(legacy)`), `owned` (derived as `!available`). Note: perks like
+  `efficiency_5pct` cap at 0.50, so `available=false` can mean either
+  "owned-once" or "maxed-out" — the UI disambiguates by reading the legacy
+  summary fields.
+- **`legacy: legacyView`** — flat summary of `*LegacyStore` (loaded once per
+  snapshot via `game.LoadLegacy()`): `total_earned`, `total_earned_fmt`,
+  `total_lp`, `spent_lp`, `lp_available` (`legacy.LPAvailable()`),
+  `starter_cash`, `efficiency_boost`, `unlocked_university`, `carried_tp`.
+
+Two small enrichments to existing views:
+
+- **`blueprintView.print_btc_cost`** (int) and **`blueprintView.print_frag_cost`**
+  (int) — same `info.Money * 3 / 10` and `info.Frags / 5` already used to
+  compute `can_print`, exposed so the UI can render a "Print (₿X / Yfrags)"
+  button label without recomputing.
+- **`stateView.pump_dump_unlocked`** (bool) and **`stateView.pump_dump_cooldown_sec`**
+  (int64) — `unlocked = s.HasUnlock("pump_dump_action")`; cooldown mirrors
+  the formula in `TriggerPumpDump` (`tick.go:486`): base 1800s, halved to
+  900s when `pump_dump_ii` is unlocked, minus `now - s.EventCooldown["pump_dump"]`,
+  clamped to 0. Both fields are zero when not unlocked — that's the "hidden"
+  signal for the UI.
+
 ### 2.11 What's already exposed (kept for clarity, no change)
 
 `state.kitten_name`, `state.btc(_fmt)`, `state.tech_point`,
@@ -223,8 +261,25 @@ already wired today, so not part of this sprint): `buy_gpu`, `switch_room`,
 `cycle_oc`, `vent`, `toggle_pause`, `unlock_skill`, `hire_merc`,
 `bribe_merc`, `fire_merc`, `reset`. These are all already in the switch.
 
-Out of scope for this sprint (engine method exists but not requested):
-`LevelUpMastery` (`mastery.go:13`), `ConvertFragsToBTC` (`mastery.go:89`),
-`TriggerPumpDump` (`tick.go:486`), `RepairAllBroken` (`events.go:362`),
-`BuyLegacyPerk` (`prestige.go:102`). These can be wired in a follow-up
-once the picker UIs land.
+### Sprint 2 wired
+
+The following actions, listed as out-of-scope for Sprint 1, were wired in
+Sprint 2:
+
+| Action key             | Engine call                                       | Body fields read           |
+| ---------------------- | ------------------------------------------------- | -------------------------- |
+| `level_up_mastery`     | `state.LevelUpMastery(id)` — `mastery.go:13`      | reuse `id`                 |
+| `convert_frags_to_btc` | `state.ConvertFragsToBTC(frags)` — `mastery.go:89`| **new** `frags int`        |
+| `trigger_pump_dump`    | `state.TriggerPumpDump()` — `tick.go:486`         | none                       |
+| `repair_all_broken`    | `state.RepairAllBroken()` — `events.go:362`       | none (returns no error)    |
+| `buy_legacy_perk`      | `game.BuyLegacyPerk(id)` — `prestige.go:102`      | reuse `id` (package-level) |
+
+Notes for future maintainers:
+- `RepairAllBroken` returns `(int, int)` with no error — the dispatch just
+  calls and discards. Surfacing the (repaired, skipped) counts is a future
+  enrichment if the UI needs it.
+- `BuyLegacyPerk` is a package-level func that mutates the on-disk
+  `LegacyStore`, not `wg.state`. The next snapshot reflects the new
+  `legacy.*` fields automatically — no extra plumbing.
+- `actionRequest` gained one new field this sprint: `frags int` (omitempty).
+  Reuses the existing `id` for the other four actions.

--- a/docs/plans/web-api-audit.md
+++ b/docs/plans/web-api-audit.md
@@ -1,0 +1,230 @@
+# Web API audit — `meowmine-web` vs engine vs design v2.1
+
+Snapshot date: 2026-04-26.
+Surfaces audited: `packages/web/cmd/meowmine-web/main.go` (`/api/snapshot`,
+`/api/action`), `packages/core/game/state.go` and siblings, `docs/GAME_DESIGN.md`
+(v2.1).
+
+The audit is split into three sections:
+
+1. Things the **design doc** wants but the **engine** doesn't have yet — out of
+   scope for this sprint, listed so we don't accidentally try to expose them.
+2. Things the **engine** already exposes on `*State` but the **web snapshot**
+   doesn't surface — the work this sprint actually does.
+3. Things the **engine** already exposes as `*State` methods but `/api/action`
+   doesn't dispatch — the action handlers added this sprint.
+
+Sections 2 & 3 drive the implementation in `main.go` + `types.ts`. Section 1 is
+backlog.
+
+---
+
+## 1. v2.1 design requires that the engine doesn't have yet
+
+**Engine-level work, deferred. Do NOT implement in this sprint.** Listed only
+so that any web-facing field for these systems has to wait until the engine
+side lands. Where the design lives in `GAME_DESIGN.md` is noted in
+parentheses.
+
+- **PSU system** — `PSUDef`, per-room `psu_units`, rated power constraint,
+  efficiency (75–95%), `heat_output`, overload tolerance, replace flow,
+  E21/E22/E26 events. (§4)
+- **Mining pool system** — `pool_id` on the run, the catalog (Solo,
+  ScratchPool, KittenHash, DarkClaw, WhiskerFi), per-pool fee + settlement
+  mode (PPS / PPLNS / PPS+), 10-minute switch transition, share accumulator,
+  pool-runaway/dilution/Solo-block events (E24, E25, E27). (§5)
+- **Stale Share rate** — per-room network-quality field, applied as
+  `effective_eff = card.eff × (1 - stale_rate)`. (§7.2)
+- **Gas Fee** — per-cashout fee `base_gas × (1 + network_congestion)` plus
+  flat per-cashout floor; `Gas Optimizer` skill. (§11.2)
+- **BTC-linked GPU resale price** — `base_resale_ratio` + `btc_sensitivity`
+  per `GPUDef`, dynamic resale formula, scrap/buy price both tied to
+  `current_btc / 30000`. (§8.1–§8.3)
+- **Net Worth panel** — `cash + btc_held × btc_price + Σ(card.resale) +
+  Σ(psu.resale × 0.7) − debt`. Drives the future Prestige threshold. (§8.4)
+- **Newton cooling temperature equilibrium** — `equilibrium = ambient +
+  max(0, total_heat - cooling) / dissipation`, `temp += (eq - temp) ×
+  approach_speed`. Today the engine uses a simpler heat-tick model in
+  `RoomState.Heat` / `RoomHeatDeltaPerTick`. Fields on `RoomDef` for
+  `ambient`, `dissipation`, and `approach_speed` don't exist yet. (§3)
+- **New events E21–E28** — PSU explode, smoking PSU, mining-disaster sell-off,
+  pool runaway, Solo block hit, PSU chain explode, share dilution, miner
+  fire-sale. None are in `data.Events()`. (§10.1)
+- **New skill nodes** — `Wiring Optimization`, `Pool Hopping`,
+  `Asset Hedging`, `Network Optimization`, `Pool Infiltration`. Not in
+  `data.Skills()`. (§9)
+
+Until the above ship in `packages/core/game/`, the snapshot must not invent
+zero-valued placeholders for them — the audit explicitly excludes that.
+
+---
+
+## 2. Engine already has it, snapshot doesn't expose it
+
+Each row: the engine field/method, where to find it, and what we're surfacing
+on the snapshot. Field naming follows the existing snake_case JSON style
+already used by `stateView` / `gpuView`.
+
+### 2.1 Top-level on `stateView`
+
+| Field on `*State`                              | Source                                                | Snapshot key (proposed)              |
+| ---------------------------------------------- | ----------------------------------------------------- | ------------------------------------ |
+| `LifetimeEarned` (raw float)                   | `state.go:132`                                         | `state.lifetime_earned`              |
+| `LegacyAvailable` (int)                        | `state.go:134`                                         | `state.legacy_available`             |
+| `Difficulty` (string)                          | `state.go:163`, `Diff()` `state.go:692`                | `state.difficulty`                   |
+| `Lang` (string)                                | `state.go:157`                                         | `state.lang`                         |
+| `PrevMarketPrice` (float64)                    | `state.go:128`                                         | `state.prev_market_price`            |
+
+`LifetimeEarnedFmt`, `MarketPrice`, `MarketTrend()`, `SyndicateJoined`,
+`Paused`, `MiningPaused` are already exposed; the new fields above sit
+next to them.
+
+### 2.2 Syndicate (extend existing `state.syndicate_joined`)
+
+| Engine                                                                                    | Snapshot key                       |
+| ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| `CanJoinSyndicate()` — `syndicate.go:48`                                                   | `state.syndicate_can_join`         |
+| `SyndicateContribution` — `state.go:152`                                                   | `state.syndicate_contribution`     |
+| `SyndicateTotalDividends` — `state.go:153`                                                 | `state.syndicate_total_dividends`  |
+| `SecondsUntilNextSyndicatePayout()` — `syndicate.go:122`                                   | `state.syndicate_next_payout_sec`  |
+
+### 2.3 GPU (extend existing `gpuView`)
+
+| Engine field on `*GPU`                | Snapshot key on each gpu          |
+| ------------------------------------- | --------------------------------- |
+| `BlueprintID` — `state.go:26`         | `blueprint_id` (`omitempty`)      |
+
+`BlueprintID` is non-empty only for printed MEOWCore instances; the existing
+naming logic at `main.go:357–361` already special-cases this — exposing the
+ID lets the future UI link a card back to its blueprint.
+
+### 2.4 Modifiers — new top-level `modifiers: []modifierView`
+
+`Modifier` shape lives at `state.go:76`. `Kind` is currently `"earn_mult"` or
+`"pause_mining"`. Snapshot view per modifier:
+
+| Field             | Source                                                  |
+| ----------------- | ------------------------------------------------------- |
+| `kind`            | `Modifier.Kind`                                          |
+| `factor`          | `Modifier.Factor`                                       |
+| `expires_at`      | `Modifier.ExpiresAt`                                    |
+| `seconds_left`    | `expires_at - time.Now().Unix()`, clamped ≥ 0           |
+
+Active list is bounded by `pruneModifiers` at `economy.go:39` — already
+called inside `Tick`, so the snapshot just iterates `s.Modifiers`.
+
+### 2.5 Active research — new top-level `active_research: researchView | null`
+
+Engine: `Research` struct at `state.go:68`, populated by `StartResearch`
+(`research.go:33`), finalised by `advanceResearch` (`research.go:89`).
+Progress helper `ResearchProgress()` at `research.go:77`.
+
+| Field           | Source                                                                  |
+| --------------- | ----------------------------------------------------------------------- |
+| `tier`          | `ActiveResearch.BlueprintTier`                                           |
+| `boosts`        | `ActiveResearch.Boosts`                                                 |
+| `started_at`    | `ActiveResearch.StartedAt`                                              |
+| `duration_sec`  | `ActiveResearch.DurationSec`                                            |
+| `progress`      | `ResearchProgress()` — already returns 0..1                             |
+| `seconds_left`  | `started_at + duration_sec - time.Now().Unix()`, clamped ≥ 0            |
+
+### 2.6 Research-tier catalog — new top-level `research_tiers: []researchTierView`
+
+Engine: `ResearchTiers()` at `research.go:30` returning
+`[]ResearchTierInfo` (`research.go:15`).
+
+Per tier: `tier`, `name`, `duration_sec`, `frags`, `money`, `min_lvl`. The UI
+needs this to render the picker that drives `start_research`.
+
+### 2.7 Blueprints — new top-level `blueprints: []blueprintView`
+
+Engine: `[]*Blueprint` at `state.go:120`, struct at `state.go:60`.
+
+| Field           | Source                                                                                         |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| `id`            | `Blueprint.ID`                                                                                  |
+| `tier`          | `Blueprint.Tier`                                                                                |
+| `boosts`        | `Blueprint.Boosts`                                                                              |
+| `created_at`    | `Blueprint.CreatedAt`                                                                           |
+| `can_print`     | derived — `BTC ≥ tierCost*0.3 && ResearchFrags ≥ tierFrags/5 && RoomHasFreeSlot(CurrentRoom)`  |
+
+`can_print` mirrors the gate inside `PrintMEOWCore` (`research.go:127`); the
+snapshot doesn't mutate, just reports affordability. Tier cost and fragments
+are looked up by walking `ResearchTiers()` for the matching `Tier`.
+
+### 2.8 Achievements — new top-level `achievements: []string`
+
+Engine: `state.go:167` (`s.Achievements`), checked by `CheckAchievements()`
+(`achievements.go:44`). Just the IDs; the catalog of names/descriptions lives
+in `data.Achievements()` (separate sprint to expose definitions).
+
+### 2.9 Mastery — new top-level `mastery_levels: map[string]int`
+
+Engine: `state.go:172` (`s.MasteryLevels`). Reading via `MasteryLevel(id)` is
+optional — the raw map is already in canonical form.
+
+### 2.10 Stats counters — new top-level `stats: statsView`
+
+Group all the lifetime counters that today live unexposed on `*State`:
+
+| Engine field                                                  | Snapshot key in `stats`                         |
+| ------------------------------------------------------------- | ----------------------------------------------- |
+| `TotalTicks` — `state.go:178`                                  | `total_ticks`                                   |
+| `TotalGPUsBought` — `state.go:179`                             | `total_gpus_bought`                             |
+| `TotalGPUsScrapped` — `state.go:180`                           | `total_gpus_scrapped`                           |
+| `OCTimeT1Sec` — `state.go:181`                                 | `oc_time_t1_sec`                                |
+| `OCTimeT2Sec` — `state.go:182`                                 | `oc_time_t2_sec`                                |
+| `TotalWagesPaid` — `state.go:184`                              | `total_wages_paid` + `total_wages_paid_fmt`    |
+| `MarketCrashCount` — `state.go:186`                            | `market_crash_count`                            |
+| `LifetimeEarned` (raw + fmt)                                   | `lifetime_earned` + `lifetime_earned_fmt`       |
+| `EventsByCategory` — `state.go:183`                            | `events_by_category`                            |
+| `MarketPriceHistory` — `state.go:185` (cap `MarketHistoryCap`) | `market_price_history`                          |
+
+### 2.11 What's already exposed (kept for clarity, no change)
+
+`state.kitten_name`, `state.btc(_fmt)`, `state.tech_point`,
+`state.research_frags`, `state.reputation`, `state.karma`,
+`state.current_room`, `state.paused`, `state.market_price`,
+`state.market_trend`, `state.lifetime_earned_fmt`, `state.room_*_fmt`,
+`state.mining_paused`, `state.syndicate_joined`, the entire `rooms`,
+`gpus`, `gpu_defs`, `skills`, `mercs`, `merc_defs`, `log`, `last_event`.
+Those keep their current shape — this sprint is additive.
+
+---
+
+## 3. Engine has it, `/api/action` doesn't dispatch it
+
+| Action key           | Engine call                                                       | Body fields read                                              |
+| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| `join_syndicate`     | `state.JoinSyndicate(time.Now().Unix())` — `syndicate.go:53`      | none                                                          |
+| `leave_syndicate`    | `state.LeaveSyndicate()` — `syndicate.go:73`                      | none                                                          |
+| `start_research`     | `state.StartResearch(tier, boosts)` — `research.go:33`            | `tier int` (default 1), `boosts []string` (must be 2 entries) |
+| `print_meowcore`     | `state.PrintMEOWCore(id)` — `research.go:127`                     | reuse existing `id` field                                     |
+| `retire`             | `state.Retire()` — `prestige.go:73` — replaces `wg.state` on success | none                                                       |
+| `set_difficulty`     | `state.SetDifficulty(id)` — `state.go:732` (no return)            | reuse existing `id` field                                     |
+| `cycle_lang`         | `state.CycleLang()` — `state.go:589`                              | none                                                          |
+
+Notes for the implementer:
+
+- `Retire` returns `(*State, int, error)`. On success swap `wg.state` and
+  reset `wg.lastEvent` / `wg.lastEventRoll` / `wg.lastEventSeq`, mirroring
+  the existing `reset` case in the action switch.
+- `actionRequest` already has `id` (used by `buy_gpu`, `unlock_skill`, etc.)
+  — `print_meowcore` and `set_difficulty` reuse it. Add optional
+  `tier int` and `boosts []string` for `start_research`; they're zero values
+  for every other action so JSON omitempty isn't required server-side.
+- `CycleLang` shifts the i18n singleton; subsequent `LocalName()` /
+  `LocalFlavor()` calls in the same snapshot will already render in the new
+  language — no extra plumbing.
+
+Future actions still missing from this list (engine has them, but they're
+already wired today, so not part of this sprint): `buy_gpu`, `switch_room`,
+`unlock_room`, `upgrade_defense`, `upgrade_gpu`, `repair_gpu`, `scrap_gpu`,
+`cycle_oc`, `vent`, `toggle_pause`, `unlock_skill`, `hire_merc`,
+`bribe_merc`, `fire_merc`, `reset`. These are all already in the switch.
+
+Out of scope for this sprint (engine method exists but not requested):
+`LevelUpMastery` (`mastery.go:13`), `ConvertFragsToBTC` (`mastery.go:89`),
+`TriggerPumpDump` (`tick.go:486`), `RepairAllBroken` (`events.go:362`),
+`BuyLegacyPerk` (`prestige.go:102`). These can be wired in a follow-up
+once the picker UIs land.

--- a/packages/web/cmd/meowmine-web/main.go
+++ b/packages/web/cmd/meowmine-web/main.go
@@ -48,6 +48,9 @@ type snapshot struct {
 	Legacy          legacyView           `json:"legacy"`
 	Stats           statsView            `json:"stats"`
 	OK              bool                 `json:"ok"`
+	DifficultyDefs  []difficultyDefView  `json:"difficulty_defs"`
+	Langs           []langOptionView     `json:"langs"`
+	EventDefs       []eventDefView       `json:"event_defs"`
 }
 
 type stateView struct {
@@ -277,6 +280,36 @@ type statsView struct {
 	LifetimeEarnedFmt  string          `json:"lifetime_earned_fmt"`
 	EventsByCategory   map[string]int  `json:"events_by_category"`
 	MarketPriceHistory []float64       `json:"market_price_history"`
+}
+
+type difficultyDefView struct {
+	ID                   string  `json:"id"`
+	Emoji                string  `json:"emoji"`
+	Label                string  `json:"label"`
+	Desc                 string  `json:"desc"`
+	EarnMult             float64 `json:"earn_mult"`
+	BillMult             float64 `json:"bill_mult"`
+	ThreatMult           float64 `json:"threat_mult"`
+	StarterCash          float64 `json:"starter_cash"`
+	MarketVolatilityMult float64 `json:"market_volatility_mult"`
+	EventFreqMult        float64 `json:"event_freq_mult"`
+	Current              bool    `json:"current"`
+}
+
+type langOptionView struct {
+	Code    string `json:"code"`
+	Label   string `json:"label"`
+	Current bool   `json:"current"`
+}
+
+type eventDefView struct {
+	ID          string `json:"id"`
+	Category    string `json:"category"`
+	Emoji       string `json:"emoji"`
+	Name        string `json:"name"`
+	Text        string `json:"text"`
+	Weight      int    `json:"weight"`
+	CooldownSec int    `json:"cooldown_sec"`
 }
 
 type actionRequest struct {
@@ -777,6 +810,47 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 		LifetimeEarnedFmt:  game.FmtBTC(s.LifetimeEarned),
 		EventsByCategory:   eventsByCat,
 		MarketPriceHistory: append([]float64{}, s.MarketPriceHistory...),
+	}
+
+	diffs := data.Difficulties()
+	out.DifficultyDefs = make([]difficultyDefView, 0, len(diffs))
+	for _, d := range diffs {
+		out.DifficultyDefs = append(out.DifficultyDefs, difficultyDefView{
+			ID:                   d.ID,
+			Emoji:                d.Emoji,
+			Label:                d.LocalLabel(),
+			Desc:                 d.LocalDesc(),
+			EarnMult:             d.EarnMult,
+			BillMult:             d.BillMult,
+			ThreatMult:           d.ThreatMult,
+			StarterCash:          d.StarterCash,
+			MarketVolatilityMult: d.MarketVolatilityMult,
+			EventFreqMult:        d.EventFreqMult,
+			Current:              d.ID == s.Difficulty,
+		})
+	}
+
+	out.Langs = make([]langOptionView, 0, len(i18n.Languages))
+	for _, code := range i18n.Languages {
+		out.Langs = append(out.Langs, langOptionView{
+			Code:    code,
+			Label:   i18n.Label(code),
+			Current: code == s.Lang,
+		})
+	}
+
+	evDefs := data.Events()
+	out.EventDefs = make([]eventDefView, 0, len(evDefs))
+	for _, def := range evDefs {
+		out.EventDefs = append(out.EventDefs, eventDefView{
+			ID:          def.ID,
+			Category:    def.Category,
+			Emoji:       def.Emoji,
+			Name:        def.LocalName(),
+			Text:        def.LocalText(),
+			Weight:      def.Weight,
+			CooldownSec: def.CooldownSec,
+		})
 	}
 
 	return out

--- a/packages/web/cmd/meowmine-web/main.go
+++ b/packages/web/cmd/meowmine-web/main.go
@@ -27,23 +27,27 @@ type webGame struct {
 }
 
 type snapshot struct {
-	State          stateView           `json:"state"`
-	Rooms          []roomView          `json:"rooms"`
-	GPUs           []gpuView           `json:"gpus"`
-	GPUDefs        []gpuDefView        `json:"gpu_defs"`
-	Skills         []skillView         `json:"skills"`
-	Mercs          []mercView          `json:"mercs"`
-	MercDefs       []mercDefView       `json:"merc_defs"`
-	Log            []logView           `json:"log"`
-	LastEvent      *eventView          `json:"last_event,omitempty"`
-	Modifiers      []modifierView      `json:"modifiers"`
-	ActiveResearch *researchView       `json:"active_research,omitempty"`
-	ResearchTiers  []researchTierView  `json:"research_tiers"`
-	Blueprints     []blueprintView     `json:"blueprints"`
-	Achievements   []string            `json:"achievements"`
-	MasteryLevels  map[string]int      `json:"mastery_levels"`
-	Stats          statsView           `json:"stats"`
-	OK             bool                `json:"ok"`
+	State           stateView            `json:"state"`
+	Rooms           []roomView           `json:"rooms"`
+	GPUs            []gpuView            `json:"gpus"`
+	GPUDefs         []gpuDefView         `json:"gpu_defs"`
+	Skills          []skillView          `json:"skills"`
+	Mercs           []mercView           `json:"mercs"`
+	MercDefs        []mercDefView        `json:"merc_defs"`
+	Log             []logView            `json:"log"`
+	LastEvent       *eventView           `json:"last_event,omitempty"`
+	Modifiers       []modifierView       `json:"modifiers"`
+	ActiveResearch  *researchView        `json:"active_research,omitempty"`
+	ResearchTiers   []researchTierView   `json:"research_tiers"`
+	Blueprints      []blueprintView      `json:"blueprints"`
+	Achievements    []string             `json:"achievements"`
+	AchievementDefs []achievementDefView `json:"achievement_defs"`
+	MasteryLevels   map[string]int       `json:"mastery_levels"`
+	MasteryTracks   []masteryTrackView   `json:"mastery_tracks"`
+	LegacyPerks     []legacyPerkView     `json:"legacy_perks"`
+	Legacy          legacyView           `json:"legacy"`
+	Stats           statsView            `json:"stats"`
+	OK              bool                 `json:"ok"`
 }
 
 type stateView struct {
@@ -73,6 +77,8 @@ type stateView struct {
 	SyndicateContribution    float64 `json:"syndicate_contribution"`
 	SyndicateTotalDividends  float64 `json:"syndicate_total_dividends"`
 	SyndicateNextPayoutSec   int64   `json:"syndicate_next_payout_sec"`
+	PumpDumpUnlocked         bool    `json:"pump_dump_unlocked"`
+	PumpDumpCooldownSec      int64   `json:"pump_dump_cooldown_sec"`
 }
 
 type roomView struct {
@@ -202,11 +208,60 @@ type researchTierView struct {
 }
 
 type blueprintView struct {
-	ID        string   `json:"id"`
-	Tier      int      `json:"tier"`
-	Boosts    []string `json:"boosts"`
-	CreatedAt int64    `json:"created_at"`
-	CanPrint  bool     `json:"can_print"`
+	ID            string   `json:"id"`
+	Tier          int      `json:"tier"`
+	Boosts        []string `json:"boosts"`
+	CreatedAt     int64    `json:"created_at"`
+	CanPrint      bool     `json:"can_print"`
+	PrintBTCCost  int      `json:"print_btc_cost"`
+	PrintFragCost int      `json:"print_frag_cost"`
+}
+
+type achievementDefView struct {
+	ID       string `json:"id"`
+	Emoji    string `json:"emoji"`
+	Name     string `json:"name"`
+	Desc     string `json:"desc"`
+	TPReward int    `json:"tp_reward"`
+	Earned   bool   `json:"earned"`
+}
+
+type masteryTrackView struct {
+	ID       string  `json:"id"`
+	Emoji    string  `json:"emoji"`
+	Name     string  `json:"name"`
+	Desc     string  `json:"desc"`
+	Effect   string  `json:"effect"`
+	PerLevel float64 `json:"per_level"`
+	Level    int     `json:"level"`
+	MaxLevel int     `json:"max_level"`
+	NextCost int     `json:"next_cost"`
+	Maxed    bool    `json:"maxed"`
+}
+
+// legacyPerkView reflects one prestige perk from game.LegacyPerks().
+// Note: perks like "efficiency_5pct" cap at 0.50, so available=false can
+// mean either "owned-once" or "maxed-out" — the UI can disambiguate by
+// reading the legacy summary fields (efficiency_boost, etc).
+type legacyPerkView struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Desc      string `json:"desc"`
+	Cost      int    `json:"cost"`
+	Available bool   `json:"available"`
+	Owned     bool   `json:"owned"`
+}
+
+type legacyView struct {
+	TotalEarned        float64 `json:"total_earned"`
+	TotalEarnedFmt     string  `json:"total_earned_fmt"`
+	TotalLP            int     `json:"total_lp"`
+	SpentLP            int     `json:"spent_lp"`
+	LPAvailable        int     `json:"lp_available"`
+	StarterCash        float64 `json:"starter_cash"`
+	EfficiencyBoost    float64 `json:"efficiency_boost"`
+	UnlockedUniversity bool    `json:"unlocked_university"`
+	CarriedTP          int     `json:"carried_tp"`
 }
 
 type statsView struct {
@@ -231,6 +286,7 @@ type actionRequest struct {
 	InstanceID int      `json:"instance_id"`
 	Tier       int      `json:"tier,omitempty"`
 	Boosts     []string `json:"boosts,omitempty"`
+	Frags      int      `json:"frags,omitempty"`
 }
 
 func main() {
@@ -350,6 +406,16 @@ func (wg *webGame) handleAction(w http.ResponseWriter, r *http.Request) {
 		wg.state.SetDifficulty(req.ID)
 	case "cycle_lang":
 		wg.state.CycleLang()
+	case "level_up_mastery":
+		_, err = wg.state.LevelUpMastery(req.ID)
+	case "convert_frags_to_btc":
+		_, err = wg.state.ConvertFragsToBTC(req.Frags)
+	case "trigger_pump_dump":
+		err = wg.state.TriggerPumpDump()
+	case "repair_all_broken":
+		wg.state.RepairAllBroken()
+	case "buy_legacy_perk":
+		err = game.BuyLegacyPerk(req.ID)
 	default:
 		err = fmt.Errorf("unknown action %q", req.Action)
 	}
@@ -384,6 +450,18 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 	now := time.Now().Unix()
 	currentEarn := s.RoomEarnRatePerSec(s.CurrentRoom)
 	currentBill := s.RoomBillRatePerSec(s.CurrentRoom)
+	legacy := game.LoadLegacy()
+
+	pumpDumpUnlocked := s.HasUnlock("pump_dump_action")
+	pumpDumpCD := int64(1800)
+	if s.HasSkill("pump_dump_ii") {
+		pumpDumpCD = 900
+	}
+	pumpDumpLeft := pumpDumpCD - (now - s.EventCooldown["pump_dump"])
+	if pumpDumpLeft < 0 || !pumpDumpUnlocked {
+		pumpDumpLeft = 0
+	}
+
 	out := snapshot{
 		State: stateView{
 			KittenName:              s.KittenName,
@@ -412,6 +490,8 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 			SyndicateContribution:   s.SyndicateContribution,
 			SyndicateTotalDividends: s.SyndicateTotalDividends,
 			SyndicateNextPayoutSec:  s.SecondsUntilNextSyndicatePayout(),
+			PumpDumpUnlocked:        pumpDumpUnlocked,
+			PumpDumpCooldownSec:     pumpDumpLeft,
 		},
 		OK: true,
 	}
@@ -598,25 +678,86 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 			}
 		}
 		canPrint := false
+		btcCost := 0
+		fragCost := 0
 		if info != nil {
-			cost := info.Money * 3 / 10
-			frags := info.Frags / 5
-			canPrint = s.BTC >= float64(cost) && s.ResearchFrags >= frags && roomFree
+			btcCost = info.Money * 3 / 10
+			fragCost = info.Frags / 5
+			canPrint = s.BTC >= float64(btcCost) && s.ResearchFrags >= fragCost && roomFree
 		}
 		out.Blueprints = append(out.Blueprints, blueprintView{
-			ID:        bp.ID,
-			Tier:      bp.Tier,
-			Boosts:    append([]string{}, bp.Boosts...),
-			CreatedAt: bp.CreatedAt,
-			CanPrint:  canPrint,
+			ID:            bp.ID,
+			Tier:          bp.Tier,
+			Boosts:        append([]string{}, bp.Boosts...),
+			CreatedAt:     bp.CreatedAt,
+			CanPrint:      canPrint,
+			PrintBTCCost:  btcCost,
+			PrintFragCost: fragCost,
 		})
 	}
 
 	out.Achievements = append([]string{}, s.Achievements...)
 
+	achDefs := data.Achievements()
+	out.AchievementDefs = make([]achievementDefView, 0, len(achDefs))
+	for _, def := range achDefs {
+		out.AchievementDefs = append(out.AchievementDefs, achievementDefView{
+			ID:       def.ID,
+			Emoji:    def.Emoji,
+			Name:     def.LocalName(),
+			Desc:     def.LocalDesc(),
+			TPReward: def.TPReward,
+			Earned:   s.HasAchievement(def.ID),
+		})
+	}
+
 	out.MasteryLevels = make(map[string]int, len(s.MasteryLevels))
 	for k, v := range s.MasteryLevels {
 		out.MasteryLevels[k] = v
+	}
+
+	mTracks := data.MasteryTracks()
+	out.MasteryTracks = make([]masteryTrackView, 0, len(mTracks))
+	for _, t := range mTracks {
+		lvl := s.MasteryLevel(t.ID)
+		out.MasteryTracks = append(out.MasteryTracks, masteryTrackView{
+			ID:       t.ID,
+			Emoji:    t.Emoji,
+			Name:     t.LocalName(),
+			Desc:     t.LocalDesc(),
+			Effect:   t.Effect,
+			PerLevel: t.PerLevel,
+			Level:    lvl,
+			MaxLevel: t.MaxLevel,
+			NextCost: t.CostFor(lvl),
+			Maxed:    lvl >= t.MaxLevel,
+		})
+	}
+
+	perks := game.LegacyPerks()
+	out.LegacyPerks = make([]legacyPerkView, 0, len(perks))
+	for _, p := range perks {
+		avail := p.Available(legacy)
+		out.LegacyPerks = append(out.LegacyPerks, legacyPerkView{
+			ID:        p.ID,
+			Name:      p.Name,
+			Desc:      p.Desc,
+			Cost:      p.Cost,
+			Available: avail,
+			Owned:     !avail,
+		})
+	}
+
+	out.Legacy = legacyView{
+		TotalEarned:        legacy.TotalEarned,
+		TotalEarnedFmt:     game.FmtBTC(legacy.TotalEarned),
+		TotalLP:            legacy.TotalLP,
+		SpentLP:            legacy.SpentLP,
+		LPAvailable:        legacy.LPAvailable(),
+		StarterCash:        legacy.StarterCash,
+		EfficiencyBoost:    legacy.EfficiencyBoost,
+		UnlockedUniversity: legacy.UnlockedUniversity,
+		CarriedTP:          legacy.CarriedTP,
 	}
 
 	eventsByCat := make(map[string]int, len(s.EventsByCategory))

--- a/packages/web/cmd/meowmine-web/main.go
+++ b/packages/web/cmd/meowmine-web/main.go
@@ -27,36 +27,52 @@ type webGame struct {
 }
 
 type snapshot struct {
-	State     stateView     `json:"state"`
-	Rooms     []roomView    `json:"rooms"`
-	GPUs      []gpuView     `json:"gpus"`
-	GPUDefs   []gpuDefView  `json:"gpu_defs"`
-	Skills    []skillView   `json:"skills"`
-	Mercs     []mercView    `json:"mercs"`
-	MercDefs  []mercDefView `json:"merc_defs"`
-	Log       []logView     `json:"log"`
-	LastEvent *eventView    `json:"last_event,omitempty"`
-	OK        bool          `json:"ok"`
+	State          stateView           `json:"state"`
+	Rooms          []roomView          `json:"rooms"`
+	GPUs           []gpuView           `json:"gpus"`
+	GPUDefs        []gpuDefView        `json:"gpu_defs"`
+	Skills         []skillView         `json:"skills"`
+	Mercs          []mercView          `json:"mercs"`
+	MercDefs       []mercDefView       `json:"merc_defs"`
+	Log            []logView           `json:"log"`
+	LastEvent      *eventView          `json:"last_event,omitempty"`
+	Modifiers      []modifierView      `json:"modifiers"`
+	ActiveResearch *researchView       `json:"active_research,omitempty"`
+	ResearchTiers  []researchTierView  `json:"research_tiers"`
+	Blueprints     []blueprintView     `json:"blueprints"`
+	Achievements   []string            `json:"achievements"`
+	MasteryLevels  map[string]int      `json:"mastery_levels"`
+	Stats          statsView           `json:"stats"`
+	OK             bool                `json:"ok"`
 }
 
 type stateView struct {
-	KittenName        string  `json:"kitten_name"`
-	BTC               float64 `json:"btc"`
-	BTCFmt            string  `json:"btc_fmt"`
-	TechPoint         int     `json:"tech_point"`
-	ResearchFrags     int     `json:"research_frags"`
-	Reputation        int     `json:"reputation"`
-	Karma             int     `json:"karma"`
-	CurrentRoom       string  `json:"current_room"`
-	Paused            bool    `json:"paused"`
-	MarketPrice       float64 `json:"market_price"`
-	MarketTrend       int     `json:"market_trend"`
-	LifetimeEarnedFmt string  `json:"lifetime_earned_fmt"`
-	RoomEarnFmt       string  `json:"room_earn_fmt"`
-	RoomBillFmt       string  `json:"room_bill_fmt"`
-	RoomNetFmt        string  `json:"room_net_fmt"`
-	MiningPaused      bool    `json:"mining_paused"`
-	SyndicateJoined   bool    `json:"syndicate_joined"`
+	KittenName               string  `json:"kitten_name"`
+	BTC                      float64 `json:"btc"`
+	BTCFmt                   string  `json:"btc_fmt"`
+	TechPoint                int     `json:"tech_point"`
+	ResearchFrags            int     `json:"research_frags"`
+	Reputation               int     `json:"reputation"`
+	Karma                    int     `json:"karma"`
+	CurrentRoom              string  `json:"current_room"`
+	Paused                   bool    `json:"paused"`
+	MarketPrice              float64 `json:"market_price"`
+	PrevMarketPrice          float64 `json:"prev_market_price"`
+	MarketTrend              int     `json:"market_trend"`
+	LifetimeEarned           float64 `json:"lifetime_earned"`
+	LifetimeEarnedFmt        string  `json:"lifetime_earned_fmt"`
+	LegacyAvailable          int     `json:"legacy_available"`
+	Difficulty               string  `json:"difficulty"`
+	Lang                     string  `json:"lang"`
+	RoomEarnFmt              string  `json:"room_earn_fmt"`
+	RoomBillFmt              string  `json:"room_bill_fmt"`
+	RoomNetFmt               string  `json:"room_net_fmt"`
+	MiningPaused             bool    `json:"mining_paused"`
+	SyndicateJoined          bool    `json:"syndicate_joined"`
+	SyndicateCanJoin         bool    `json:"syndicate_can_join"`
+	SyndicateContribution    float64 `json:"syndicate_contribution"`
+	SyndicateTotalDividends  float64 `json:"syndicate_total_dividends"`
+	SyndicateNextPayoutSec   int64   `json:"syndicate_next_payout_sec"`
 }
 
 type roomView struct {
@@ -90,19 +106,20 @@ type defenseView struct {
 }
 
 type gpuView struct {
-	InstanceID int     `json:"instance_id"`
-	DefID      string  `json:"def_id"`
-	Name       string  `json:"name"`
-	Status     string  `json:"status"`
-	Room       string  `json:"room"`
-	Upgrade    int     `json:"upgrade"`
-	OCLevel    int     `json:"oc_level"`
-	HoursLeft  float64 `json:"hours_left"`
-	EarnFmt    string  `json:"earn_fmt"`
-	Repairable bool    `json:"repairable"`
-	ShipsAt      int64 `json:"ships_at,omitempty"`
-	ShipEtaSec   int64 `json:"ship_eta_sec,omitempty"`
-	ShipTotalSec int64 `json:"ship_total_sec,omitempty"`
+	InstanceID   int     `json:"instance_id"`
+	DefID        string  `json:"def_id"`
+	BlueprintID  string  `json:"blueprint_id,omitempty"`
+	Name         string  `json:"name"`
+	Status       string  `json:"status"`
+	Room         string  `json:"room"`
+	Upgrade      int     `json:"upgrade"`
+	OCLevel      int     `json:"oc_level"`
+	HoursLeft    float64 `json:"hours_left"`
+	EarnFmt      string  `json:"earn_fmt"`
+	Repairable   bool    `json:"repairable"`
+	ShipsAt      int64   `json:"ships_at,omitempty"`
+	ShipEtaSec   int64   `json:"ship_eta_sec,omitempty"`
+	ShipTotalSec int64   `json:"ship_total_sec,omitempty"`
 }
 
 type gpuDefView struct {
@@ -159,11 +176,61 @@ type eventView struct {
 	Text     string `json:"text"`
 }
 
+type modifierView struct {
+	Kind        string  `json:"kind"`
+	Factor      float64 `json:"factor"`
+	ExpiresAt   int64   `json:"expires_at"`
+	SecondsLeft int64   `json:"seconds_left"`
+}
+
+type researchView struct {
+	Tier        int      `json:"tier"`
+	Boosts      []string `json:"boosts"`
+	StartedAt   int64    `json:"started_at"`
+	DurationSec int      `json:"duration_sec"`
+	Progress    float64  `json:"progress"`
+	SecondsLeft int64    `json:"seconds_left"`
+}
+
+type researchTierView struct {
+	Tier        int    `json:"tier"`
+	Name        string `json:"name"`
+	DurationSec int    `json:"duration_sec"`
+	Frags       int    `json:"frags"`
+	Money       int    `json:"money"`
+	MinLvl      int    `json:"min_lvl"`
+}
+
+type blueprintView struct {
+	ID        string   `json:"id"`
+	Tier      int      `json:"tier"`
+	Boosts    []string `json:"boosts"`
+	CreatedAt int64    `json:"created_at"`
+	CanPrint  bool     `json:"can_print"`
+}
+
+type statsView struct {
+	TotalTicks         int64           `json:"total_ticks"`
+	TotalGPUsBought    int             `json:"total_gpus_bought"`
+	TotalGPUsScrapped  int             `json:"total_gpus_scrapped"`
+	OCTimeT1Sec        int64           `json:"oc_time_t1_sec"`
+	OCTimeT2Sec        int64           `json:"oc_time_t2_sec"`
+	TotalWagesPaid     float64         `json:"total_wages_paid"`
+	TotalWagesPaidFmt  string          `json:"total_wages_paid_fmt"`
+	MarketCrashCount   int             `json:"market_crash_count"`
+	LifetimeEarned     float64         `json:"lifetime_earned"`
+	LifetimeEarnedFmt  string          `json:"lifetime_earned_fmt"`
+	EventsByCategory   map[string]int  `json:"events_by_category"`
+	MarketPriceHistory []float64       `json:"market_price_history"`
+}
+
 type actionRequest struct {
-	Action     string `json:"action"`
-	ID         string `json:"id"`
-	Dim        string `json:"dim"`
-	InstanceID int    `json:"instance_id"`
+	Action     string   `json:"action"`
+	ID         string   `json:"id"`
+	Dim        string   `json:"dim"`
+	InstanceID int      `json:"instance_id"`
+	Tier       int      `json:"tier,omitempty"`
+	Boosts     []string `json:"boosts,omitempty"`
 }
 
 func main() {
@@ -258,6 +325,31 @@ func (wg *webGame) handleAction(w http.ResponseWriter, r *http.Request) {
 		wg.lastEvent = nil
 		wg.lastEventRoll = 0
 		wg.lastEventSeq = 0
+	case "join_syndicate":
+		err = wg.state.JoinSyndicate(time.Now().Unix())
+	case "leave_syndicate":
+		err = wg.state.LeaveSyndicate()
+	case "start_research":
+		tier := req.Tier
+		if tier == 0 {
+			tier = 1
+		}
+		err = wg.state.StartResearch(tier, req.Boosts)
+	case "print_meowcore":
+		err = wg.state.PrintMEOWCore(req.ID)
+	case "retire":
+		var fresh *game.State
+		fresh, _, err = wg.state.Retire()
+		if err == nil && fresh != nil {
+			wg.state = fresh
+			wg.lastEvent = nil
+			wg.lastEventRoll = 0
+			wg.lastEventSeq = 0
+		}
+	case "set_difficulty":
+		wg.state.SetDifficulty(req.ID)
+	case "cycle_lang":
+		wg.state.CycleLang()
 	default:
 		err = fmt.Errorf("unknown action %q", req.Action)
 	}
@@ -289,27 +381,37 @@ func (wg *webGame) advanceLocked() {
 
 func (wg *webGame) makeSnapshotLocked() snapshot {
 	s := wg.state
+	now := time.Now().Unix()
 	currentEarn := s.RoomEarnRatePerSec(s.CurrentRoom)
 	currentBill := s.RoomBillRatePerSec(s.CurrentRoom)
 	out := snapshot{
 		State: stateView{
-			KittenName:        s.KittenName,
-			BTC:               s.BTC,
-			BTCFmt:            game.FmtBTC(s.BTC),
-			TechPoint:         s.TechPoint,
-			ResearchFrags:     s.ResearchFrags,
-			Reputation:        s.Reputation,
-			Karma:             s.Karma,
-			CurrentRoom:       s.CurrentRoom,
-			Paused:            s.Paused,
-			MarketPrice:       s.MarketPrice,
-			MarketTrend:       s.MarketTrend(),
-			LifetimeEarnedFmt: game.FmtBTC(s.LifetimeEarned),
-			RoomEarnFmt:       game.FmtBTC(currentEarn) + "/s",
-			RoomBillFmt:       game.FmtBTC(currentBill) + "/s",
-			RoomNetFmt:        game.FmtBTCSigned(currentEarn-currentBill) + "/s",
-			MiningPaused:      s.IsMiningPaused(time.Now().Unix()),
-			SyndicateJoined:   s.SyndicateJoined,
+			KittenName:              s.KittenName,
+			BTC:                     s.BTC,
+			BTCFmt:                  game.FmtBTC(s.BTC),
+			TechPoint:               s.TechPoint,
+			ResearchFrags:           s.ResearchFrags,
+			Reputation:              s.Reputation,
+			Karma:                   s.Karma,
+			CurrentRoom:             s.CurrentRoom,
+			Paused:                  s.Paused,
+			MarketPrice:             s.MarketPrice,
+			PrevMarketPrice:         s.PrevMarketPrice,
+			MarketTrend:             s.MarketTrend(),
+			LifetimeEarned:          s.LifetimeEarned,
+			LifetimeEarnedFmt:       game.FmtBTC(s.LifetimeEarned),
+			LegacyAvailable:         s.LegacyAvailable,
+			Difficulty:              s.Difficulty,
+			Lang:                    s.Lang,
+			RoomEarnFmt:             game.FmtBTC(currentEarn) + "/s",
+			RoomBillFmt:             game.FmtBTC(currentBill) + "/s",
+			RoomNetFmt:              game.FmtBTCSigned(currentEarn-currentBill) + "/s",
+			MiningPaused:            s.IsMiningPaused(now),
+			SyndicateJoined:         s.SyndicateJoined,
+			SyndicateCanJoin:        s.CanJoinSyndicate(),
+			SyndicateContribution:   s.SyndicateContribution,
+			SyndicateTotalDividends: s.SyndicateTotalDividends,
+			SyndicateNextPayoutSec:  s.SecondsUntilNextSyndicatePayout(),
 		},
 		OK: true,
 	}
@@ -351,7 +453,6 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 		out.Rooms = append(out.Rooms, room)
 	}
 
-	nowUnix := time.Now().Unix()
 	for _, g := range s.GPUs {
 		name := g.DefID
 		if def, ok := data.GPUByID(g.DefID); ok {
@@ -360,20 +461,21 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 			name = "MEOWCore"
 		}
 		view := gpuView{
-			InstanceID: g.InstanceID,
-			DefID:      g.DefID,
-			Name:       name,
-			Status:     g.Status,
-			Room:       g.Room,
-			Upgrade:    g.UpgradeLevel,
-			OCLevel:    g.OCLevel,
-			HoursLeft:  g.HoursLeft,
-			EarnFmt:    game.FmtBTC(s.GPUEarnRatePerSec(g)) + "/s",
-			Repairable: g.Status == "broken",
+			InstanceID:  g.InstanceID,
+			DefID:       g.DefID,
+			BlueprintID: g.BlueprintID,
+			Name:        name,
+			Status:      g.Status,
+			Room:        g.Room,
+			Upgrade:     g.UpgradeLevel,
+			OCLevel:     g.OCLevel,
+			HoursLeft:   g.HoursLeft,
+			EarnFmt:     game.FmtBTC(s.GPUEarnRatePerSec(g)) + "/s",
+			Repairable:  g.Status == "broken",
 		}
 		if g.Status == "shipping" && g.ShipsAt > 0 {
 			view.ShipsAt = g.ShipsAt
-			eta := g.ShipsAt - nowUnix
+			eta := g.ShipsAt - now
 			if eta < 0 {
 				eta = 0
 			}
@@ -442,6 +544,100 @@ func (wg *webGame) makeSnapshotLocked() snapshot {
 		out.Log = append(out.Log, logView{Time: e.Time, Category: e.Category, Text: e.Text})
 	}
 	out.LastEvent = wg.lastEvent
+
+	out.Modifiers = make([]modifierView, 0, len(s.Modifiers))
+	for _, m := range s.Modifiers {
+		left := m.ExpiresAt - now
+		if left < 0 {
+			left = 0
+		}
+		out.Modifiers = append(out.Modifiers, modifierView{
+			Kind:        m.Kind,
+			Factor:      m.Factor,
+			ExpiresAt:   m.ExpiresAt,
+			SecondsLeft: left,
+		})
+	}
+
+	tiers := game.ResearchTiers()
+	if s.ActiveResearch != nil {
+		left := s.ActiveResearch.StartedAt + int64(s.ActiveResearch.DurationSec) - now
+		if left < 0 {
+			left = 0
+		}
+		out.ActiveResearch = &researchView{
+			Tier:        s.ActiveResearch.BlueprintTier,
+			Boosts:      append([]string{}, s.ActiveResearch.Boosts...),
+			StartedAt:   s.ActiveResearch.StartedAt,
+			DurationSec: s.ActiveResearch.DurationSec,
+			Progress:    s.ResearchProgress(),
+			SecondsLeft: left,
+		}
+	}
+
+	out.ResearchTiers = make([]researchTierView, 0, len(tiers))
+	for _, t := range tiers {
+		out.ResearchTiers = append(out.ResearchTiers, researchTierView{
+			Tier:        t.Tier,
+			Name:        t.Name,
+			DurationSec: t.Duration,
+			Frags:       t.Frags,
+			Money:       t.Money,
+			MinLvl:      t.MinLvl,
+		})
+	}
+
+	roomFree := s.RoomHasFreeSlot(s.CurrentRoom)
+	out.Blueprints = make([]blueprintView, 0, len(s.Blueprints))
+	for _, bp := range s.Blueprints {
+		var info *game.ResearchTierInfo
+		for i := range tiers {
+			if tiers[i].Tier == bp.Tier {
+				info = &tiers[i]
+				break
+			}
+		}
+		canPrint := false
+		if info != nil {
+			cost := info.Money * 3 / 10
+			frags := info.Frags / 5
+			canPrint = s.BTC >= float64(cost) && s.ResearchFrags >= frags && roomFree
+		}
+		out.Blueprints = append(out.Blueprints, blueprintView{
+			ID:        bp.ID,
+			Tier:      bp.Tier,
+			Boosts:    append([]string{}, bp.Boosts...),
+			CreatedAt: bp.CreatedAt,
+			CanPrint:  canPrint,
+		})
+	}
+
+	out.Achievements = append([]string{}, s.Achievements...)
+
+	out.MasteryLevels = make(map[string]int, len(s.MasteryLevels))
+	for k, v := range s.MasteryLevels {
+		out.MasteryLevels[k] = v
+	}
+
+	eventsByCat := make(map[string]int, len(s.EventsByCategory))
+	for k, v := range s.EventsByCategory {
+		eventsByCat[k] = v
+	}
+	out.Stats = statsView{
+		TotalTicks:         s.TotalTicks,
+		TotalGPUsBought:    s.TotalGPUsBought,
+		TotalGPUsScrapped:  s.TotalGPUsScrapped,
+		OCTimeT1Sec:        s.OCTimeT1Sec,
+		OCTimeT2Sec:        s.OCTimeT2Sec,
+		TotalWagesPaid:     s.TotalWagesPaid,
+		TotalWagesPaidFmt:  game.FmtBTC(s.TotalWagesPaid),
+		MarketCrashCount:   s.MarketCrashCount,
+		LifetimeEarned:     s.LifetimeEarned,
+		LifetimeEarnedFmt:  game.FmtBTC(s.LifetimeEarned),
+		EventsByCategory:   eventsByCat,
+		MarketPriceHistory: append([]float64{}, s.MarketPriceHistory...),
+	}
+
 	return out
 }
 

--- a/packages/web/frontend/src/lib/slotStats.test.ts
+++ b/packages/web/frontend/src/lib/slotStats.test.ts
@@ -38,6 +38,9 @@ function snap(gpus: GPU[]): Snapshot {
     legacy: {} as Snapshot["legacy"],
     stats: {} as Snapshot["stats"],
     ok: true,
+    difficulty_defs: [],
+    langs: [],
+    event_defs: [],
   };
 }
 

--- a/packages/web/frontend/src/lib/slotStats.test.ts
+++ b/packages/web/frontend/src/lib/slotStats.test.ts
@@ -31,7 +31,11 @@ function snap(gpus: GPU[]): Snapshot {
     research_tiers: [],
     blueprints: [],
     achievements: [],
+    achievement_defs: [],
     mastery_levels: {},
+    mastery_tracks: [],
+    legacy_perks: [],
+    legacy: {} as Snapshot["legacy"],
     stats: {} as Snapshot["stats"],
     ok: true,
   };

--- a/packages/web/frontend/src/lib/slotStats.test.ts
+++ b/packages/web/frontend/src/lib/slotStats.test.ts
@@ -27,6 +27,12 @@ function snap(gpus: GPU[]): Snapshot {
     mercs: [],
     merc_defs: [],
     log: [],
+    modifiers: [],
+    research_tiers: [],
+    blueprints: [],
+    achievements: [],
+    mastery_levels: {},
+    stats: {} as Snapshot["stats"],
     ok: true,
   };
 }

--- a/packages/web/frontend/src/types.ts
+++ b/packages/web/frontend/src/types.ts
@@ -20,6 +20,9 @@ export interface Snapshot {
   legacy: LegacySummary;
   stats: Stats;
   ok: boolean;
+  difficulty_defs: DifficultyDef[];
+  langs: LangOption[];
+  event_defs: EventDef[];
 }
 
 export interface GameState {
@@ -245,6 +248,36 @@ export interface Stats {
   lifetime_earned_fmt: string;
   events_by_category: Record<string, number>;
   market_price_history: number[];
+}
+
+export interface DifficultyDef {
+  id: string;
+  emoji: string;
+  label: string;
+  desc: string;
+  earn_mult: number;
+  bill_mult: number;
+  threat_mult: number;
+  starter_cash: number;
+  market_volatility_mult: number;
+  event_freq_mult: number;
+  current: boolean;
+}
+
+export interface LangOption {
+  code: string;
+  label: string;
+  current: boolean;
+}
+
+export interface EventDef {
+  id: string;
+  category: string;
+  emoji: string;
+  name: string;
+  text: string;
+  weight: number;
+  cooldown_sec: number;
 }
 
 export interface ActionRequest {

--- a/packages/web/frontend/src/types.ts
+++ b/packages/web/frontend/src/types.ts
@@ -13,7 +13,11 @@ export interface Snapshot {
   research_tiers: ResearchTier[];
   blueprints: Blueprint[];
   achievements: string[];
+  achievement_defs: AchievementDef[];
   mastery_levels: Record<string, number>;
+  mastery_tracks: MasteryTrack[];
+  legacy_perks: LegacyPerk[];
+  legacy: LegacySummary;
   stats: Stats;
   ok: boolean;
 }
@@ -45,6 +49,8 @@ export interface GameState {
   syndicate_contribution: number;
   syndicate_total_dividends: number;
   syndicate_next_payout_sec: number;
+  pump_dump_unlocked: boolean;
+  pump_dump_cooldown_sec: number;
 }
 
 export interface Room {
@@ -179,6 +185,51 @@ export interface Blueprint {
   boosts: string[];
   created_at: number;
   can_print: boolean;
+  print_btc_cost: number;
+  print_frag_cost: number;
+}
+
+export interface AchievementDef {
+  id: string;
+  emoji: string;
+  name: string;
+  desc: string;
+  tp_reward: number;
+  earned: boolean;
+}
+
+export interface MasteryTrack {
+  id: string;
+  emoji: string;
+  name: string;
+  desc: string;
+  effect: string;
+  per_level: number;
+  level: number;
+  max_level: number;
+  next_cost: number;
+  maxed: boolean;
+}
+
+export interface LegacyPerk {
+  id: string;
+  name: string;
+  desc: string;
+  cost: number;
+  available: boolean;
+  owned: boolean;
+}
+
+export interface LegacySummary {
+  total_earned: number;
+  total_earned_fmt: string;
+  total_lp: number;
+  spent_lp: number;
+  lp_available: number;
+  starter_cash: number;
+  efficiency_boost: number;
+  unlocked_university: boolean;
+  carried_tp: number;
 }
 
 export interface Stats {
@@ -203,6 +254,7 @@ export interface ActionRequest {
   instance_id?: number;
   tier?: number;
   boosts?: string[];
+  frags?: number;
 }
 
 export type TabId =

--- a/packages/web/frontend/src/types.ts
+++ b/packages/web/frontend/src/types.ts
@@ -8,6 +8,13 @@ export interface Snapshot {
   merc_defs: MercDef[];
   log: LogEntry[];
   last_event?: GameEvent;
+  modifiers: Modifier[];
+  active_research?: ActiveResearch;
+  research_tiers: ResearchTier[];
+  blueprints: Blueprint[];
+  achievements: string[];
+  mastery_levels: Record<string, number>;
+  stats: Stats;
   ok: boolean;
 }
 
@@ -22,13 +29,22 @@ export interface GameState {
   current_room: string;
   paused: boolean;
   market_price: number;
+  prev_market_price: number;
   market_trend: number;
+  lifetime_earned: number;
   lifetime_earned_fmt: string;
+  legacy_available: number;
+  difficulty: string;
+  lang: string;
   room_earn_fmt: string;
   room_bill_fmt: string;
   room_net_fmt: string;
   mining_paused: boolean;
   syndicate_joined: boolean;
+  syndicate_can_join: boolean;
+  syndicate_contribution: number;
+  syndicate_total_dividends: number;
+  syndicate_next_payout_sec: number;
 }
 
 export interface Room {
@@ -64,6 +80,7 @@ export interface Defense {
 export interface GPU {
   instance_id: number;
   def_id: string;
+  blueprint_id?: string;
   name: string;
   status: string;
   room: string;
@@ -131,11 +148,61 @@ export interface GameEvent {
   text: string;
 }
 
+export interface Modifier {
+  kind: string;
+  factor: number;
+  expires_at: number;
+  seconds_left: number;
+}
+
+export interface ActiveResearch {
+  tier: number;
+  boosts: string[];
+  started_at: number;
+  duration_sec: number;
+  progress: number;
+  seconds_left: number;
+}
+
+export interface ResearchTier {
+  tier: number;
+  name: string;
+  duration_sec: number;
+  frags: number;
+  money: number;
+  min_lvl: number;
+}
+
+export interface Blueprint {
+  id: string;
+  tier: number;
+  boosts: string[];
+  created_at: number;
+  can_print: boolean;
+}
+
+export interface Stats {
+  total_ticks: number;
+  total_gpus_bought: number;
+  total_gpus_scrapped: number;
+  oc_time_t1_sec: number;
+  oc_time_t2_sec: number;
+  total_wages_paid: number;
+  total_wages_paid_fmt: string;
+  market_crash_count: number;
+  lifetime_earned: number;
+  lifetime_earned_fmt: string;
+  events_by_category: Record<string, number>;
+  market_price_history: number[];
+}
+
 export interface ActionRequest {
   action: string;
   id?: string;
   dim?: string;
   instance_id?: number;
+  tier?: number;
+  boosts?: string[];
 }
 
 export type TabId =


### PR DESCRIPTION
## Summary
- 把 `*State` 已实现但 `/api/snapshot` 没透出的字段一次性暴露(11 个 state 字段、6 个新 top-level catalog)
- `/api/action` 补齐 12 个未连线动作(syndicate / research / mastery / legacy / pump_dump 等)
- 暴露设计目录(achievements / mastery_tracks / legacy_perks / blueprints / difficulty_defs / langs / event_defs)以便前端不再硬编码 picker
- 严格 additive,既有字段 / 行为 / JSON 形状不变;`packages/web/frontend/src/types.ts` 全字段同步

## Features

### 1. Engine-surface alignment (`65f9004`)
- `stateView` +11 字段:`lifetime_earned`(原值)、`legacy_available`、`difficulty`、`lang`、`prev_market_price` 加 4 个 syndicate 字段
- 新增 top-level: `modifiers`、`active_research`、`research_tiers`、`blueprints`、`achievements`、`mastery_levels`、`stats`
- `gpuView` +`blueprint_id`(omitempty)
- `/api/action` +`join_syndicate`、`leave_syndicate`、`start_research`、`print_meowcore`、`retire`、`set_difficulty`、`cycle_lang`
- 新建 `docs/plans/web-api-audit.md` 作为审计 / 后续工作清单

### 2. Follow-up actions + design catalogs (`d746be8`)
- `/api/action` +`level_up_mastery`、`convert_frags_to_btc`、`trigger_pump_dump`、`repair_all_broken`、`buy_legacy_perk`
- 新增 catalog: `achievement_defs`(18 条 emoji+name+desc+tp_reward+earned)、`mastery_tracks`(5 条,level/next_cost/maxed)、`legacy_perks`(3 条,available/owned)、扁平 `legacy` 摘要
- `blueprintView` +`print_btc_cost` / `print_frag_cost`;`stateView` +`pump_dump_unlocked` / `pump_dump_cooldown_sec`

### 3. Picker catalogs (`d04101e`)
- `difficulty_defs`(4 档,emoji+本地化 label/desc+经济/threat/volatility/event 倍数+starter_cash+current 标记)
- `langs`(`i18n.Languages`,code+label+current)
- `event_defs`(完整 `data.Events()`,id/category/emoji/本地化 name+text/weight/cooldown_sec)

## Out of scope (audit Section 1 — 引擎工作)

`docs/plans/web-api-audit.md` Section 1 列出的 v2.1 引擎级机制(PSU、矿池、Stale Share、Gas Fee、BTC 联动二手价、Net Worth、Newton 冷却、E21–E28、Wiring/Pool/Hedging/Network/Infiltration 技能)需要先在 `packages/core/game/` 落地才能在 API 透出。本 PR 严格遵守"不发明零值占位"。

## Test plan
- [x] `go build ./packages/web/cmd/meowmine-web`
- [x] `go test ./packages/core/game/ ./packages/core/data/`
- [x] `cd packages/web/frontend && npm run typecheck`
- [x] `cd packages/web/frontend && npm run test -- --run`
- [x] `cd packages/web/frontend && npm run build`
- [ ] 手测:`make run-web` 后 `curl localhost:8080/api/snapshot | jq '.modifiers, .achievement_defs[0], .difficulty_defs, .event_defs | length'` 看新字段就位
- [ ] 手测:对每个新 action 各打一次 `POST /api/action` 验签

🤖 Generated with [Claude Code](https://claude.com/claude-code)
